### PR TITLE
fix: diff gutter desync on deleted --- lines, freeze on long highlighted lines

### DIFF
--- a/plugins/herdr-sidebar/src/diffview.rs
+++ b/plugins/herdr-sidebar/src/diffview.rs
@@ -36,11 +36,14 @@ fn parse_events(diff: &str) -> Vec<Ev> {
     let mut old_no = 0usize;
     let mut new_no = 0usize;
     let mut seen_hunk = false;
+    let mut in_hunk = false;
     for line in diff.lines() {
-        if line.starts_with("diff --git")
+        if line.starts_with("diff --git") {
+            in_hunk = false;
+        }
+        if (!in_hunk && (line.starts_with("--- ") || line.starts_with("+++ ")))
+            || line.starts_with("diff --git")
             || line.starts_with("index ")
-            || line.starts_with("--- ")
-            || line.starts_with("+++ ")
             || line.starts_with("old mode")
             || line.starts_with("new mode")
             || line.starts_with("similarity")
@@ -53,6 +56,7 @@ fn parse_events(diff: &str) -> Vec<Ev> {
             continue;
         }
         if line.starts_with("@@") {
+            in_hunk = true;
             for tok in line.split_whitespace() {
                 let (sign, rest) = match tok.split_at_checked(1) {
                     Some(pair) => pair,
@@ -299,6 +303,28 @@ mod tests {
             .iter()
             .all(|s| s.style.bg != Some(ADD_WORD_BG));
         assert!(plain_add);
+    }
+
+    #[test]
+    fn deleted_line_starting_with_dashes_does_not_desync_gutters() {
+        // A deleted SQL/Lua-style "-- comment" line looks exactly like a
+        // "--- a/file" header if the parser isn't hunk-aware.
+        let diff = concat!(
+            "diff --git a/q.sql b/q.sql\n",
+            "index 111..222 100644\n",
+            "--- a/q.sql\n",
+            "+++ b/q.sql\n",
+            "@@ -1,3 +1,2 @@\n",
+            " SELECT 1;\n",
+            "--- trailing comment\n",
+            " SELECT 2;\n",
+        );
+        let lines = render("q.sql", diff);
+        assert_eq!(lines.len(), 3, "the deleted comment line must render");
+        assert!(lines[0].to_string().starts_with(" 1  1"));
+        assert!(lines[1].to_string().contains("-- trailing comment"));
+        // Old-side numbering must not skip: line 3 is old line 3, not 2.
+        assert!(lines[2].to_string().starts_with(" 3  2"));
     }
 
     #[test]

--- a/plugins/herdr-sidebar/src/syntax.rs
+++ b/plugins/herdr-sidebar/src/syntax.rs
@@ -13,6 +13,12 @@ use syntect::highlighting::{FontStyle, Theme, ThemeSet};
 use syntect::parsing::SyntaxSet;
 use syntect::util::LinesWithEndings;
 
+/// Lines longer than this skip highlighting entirely. syntect's `regex-fancy`
+/// backtracking engine is roughly quadratic in line length on pathological
+/// input (minified JS/CSS, generated data) — a single multi-hundred-KB line
+/// can take tens of seconds and freeze the render thread.
+const MAX_HIGHLIGHT_LINE_LEN: usize = 2000;
+
 /// Grammar + theme assets, loaded once (the bundled dumps take a few ms).
 fn assets() -> &'static (SyntaxSet, Theme) {
     static ASSETS: OnceLock<(SyntaxSet, Theme)> = OnceLock::new();
@@ -41,6 +47,10 @@ pub fn highlight(name: &str, text: &str, max: usize) -> Option<Vec<Line<'static>
     let mut highlighter = HighlightLines::new(syntax, theme);
     let mut lines = Vec::new();
     for raw in LinesWithEndings::from(text).take(max) {
+        if raw.len() > MAX_HIGHLIGHT_LINE_LEN {
+            lines.push(Line::raw(raw.trim_end_matches(['\n', '\r']).to_string()));
+            continue;
+        }
         let Ok(regions) = highlighter.highlight_line(raw, syntaxes) else {
             lines.push(Line::raw(raw.trim_end_matches(['\n', '\r']).to_string()));
             continue;
@@ -89,6 +99,9 @@ impl LineHighlighter {
         let Some(hl) = self.inner.as_mut() else {
             return vec![Span::raw(text.to_string())];
         };
+        if text.len() > MAX_HIGHLIGHT_LINE_LEN {
+            return vec![Span::raw(text.to_string())];
+        }
         let (syntaxes, _) = assets();
         let with_nl = format!("{text}\n");
         match hl.highlight_line(&with_nl, syntaxes) {
@@ -144,5 +157,18 @@ name = \"x\"
     #[test]
     fn unknown_extensions_fall_back_to_none() {
         assert!(highlight("data.qqzz", "gibberish content\n", 10).is_none());
+    }
+
+    #[test]
+    fn pathologically_long_lines_skip_highlighting_instead_of_hanging() {
+        let long_line = format!("const x = \"{}\";\n", "a".repeat(MAX_HIGHLIGHT_LINE_LEN + 1));
+        let lines = highlight("bundle.min.js", &long_line, 10).expect("js grammar matches");
+        assert_eq!(lines.len(), 1);
+        assert_eq!(lines[0].to_string(), long_line.trim_end_matches('\n'));
+
+        let mut hl = LineHighlighter::new("bundle.min.js");
+        let spans = hl.line(long_line.trim_end_matches('\n'));
+        assert_eq!(spans.len(), 1);
+        assert_eq!(spans[0].content, long_line.trim_end_matches('\n'));
     }
 }


### PR DESCRIPTION
## What

Two independent correctness fixes in the diff/preview rendering path:

1. **`diffview.rs`** — a deleted or added content line that happens to start with `--`/`++` (e.g. a SQL/Lua-style `-- comment`) was mistaken for a `---`/`+++` file-header line and silently dropped. The dropped line never rendered, and `old_no`/`new_no` were never incremented for it, so every subsequent line number in that hunk was off by one for the rest of the diff.
2. **`syntax.rs`** — no cap on line length before handing a line to syntect's `highlight_line`. syntect's pure-Rust `regex-fancy` backtracking engine scales badly with line length; a single very long line (e.g. a minified `.js`/`.css` file) can take tens of seconds to highlight, freezing the render thread. Because the diff viewer re-runs highlighting on its ~2s live-refresh loop — faster than one such render completes — the pane stops responding to input entirely and has to be killed.

## Why it matters

1. Any repo touching SQL/Lua/Haskell/Elm-style `--`-prefixed comments (or similarly `++`-prefixed content) in a diff gets a **silently wrong line-number gutter** from that point on — misleading for anyone using the numbers to navigate or reference the diff.
2. Opening a diff or preview on a minified/generated/bundled file **freezes the sidebar pane with no way to cancel** (not even Esc/q), since the offending render blocks the event loop and re-triggers before it can finish.

## Fix

1. Track an `in_hunk` flag, set at `@@` and cleared at the next `diff --git` (so multi-file diffs still filter real file headers). The `---`/`+++` header filter now only applies outside a hunk — inside a hunk, those prefixes are handled by the existing `-`/`+` content-line logic like any other line.
2. Add a `MAX_HIGHLIGHT_LINE_LEN` (2000 char) cutoff in both `syntax::highlight` and `LineHighlighter::line`: lines over the cap render as plain unstyled text instead of going through syntect.

## Test plan

- `cargo test` — 89 passed, including two new regression tests:
  - `diffview::tests::deleted_line_starting_with_dashes_does_not_desync_gutters` — constructs a hunk with a deleted `-- trailing comment` line and asserts the old-side gutter for the following context line is correct (fails without the fix).
  - `syntax::tests::pathologically_long_lines_skip_highlighting_instead_of_hanging` — asserts a line over the cap renders as plain raw text via both `highlight()` and `LineHighlighter::line()`.
- `cargo clippy -- -D warnings` — clean.

No platform-specific code; both fixes are pure logic and apply identically on all platforms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)