### PR TITLE
feat: "Open with Default App" in the file context menus

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -318,6 +318,16 @@ HACKING.md — budget time for that before promising a patched build.
   pane a corpse after 20s. "Change Folder (Type Path)…" keeps the typed prompt (absolute,
   relative, or ~-prefixed); either path swaps the PROCESS cwd, so the other view follows
   on its next switch.
+- "Open with Default App" (`actions::open_external`, in the Explorer menu for FILE rows
+  only and in the SCM file menu unless the entry's status letter is `D`) hands the path to
+  the OS shell association. Windows uses `explorer.exe <path>`, NOT `cmd /c start`: explorer
+  is GUI-subsystem, so no console is created and Windows 11 never flashes a Windows Terminal
+  window; it resolves the association exactly like a double click (verified live — a .html
+  row launched the ChromeHTML handler; a broken/unregistered association falls back to the
+  shell's own "Open with" dialog, which is correct behavior). Its exit code is unreliable
+  (explorer routinely returns 1 on success), so only the SPAWN is reported. Directories are
+  deliberately excluded — their association IS the file manager, which "Reveal in File
+  Explorer" already covers.
 - List UX invariants (both views): NOTHING is highlighted until the user selects
   (hover stays subtle); the wheel scrolls the VIEW only (`scroll_view`) and never
   moves the selection; keyboard nav snaps the view to the selection; overflow shows a

--- a/README.md
+++ b/README.md
@@ -58,8 +58,9 @@ A real tree, not a directory dump:
   50/50 split instead? toggle "Full-size preview" off in ⚙ Settings). Line numbers,
   scrolling, binary-safe). Click another file — the same pane updates in place.
 - **Double-click folders** to fold, hover highlights, mouse wheel, and a
-  **Ctrl+right-click context menu**: New File, New Folder, Rename, Delete, Copy Path /
-  Relative Path, Reveal in File Explorer.
+  **Ctrl+right-click context menu**: New File, New Folder, Open with Default App (files
+  only — hands the file to the OS-associated app, like a double click in the file
+  manager), Rename, Delete, Copy Path / Relative Path, Reveal in File Explorer.
 - Dotfiles toggle, live refresh, and a collapse-to-sliver mode when you want the columns back.
 
 ### 🔀 Source Control

--- a/plugins/herdr-sidebar/src/actions.rs
+++ b/plugins/herdr-sidebar/src/actions.rs
@@ -13,6 +13,7 @@ pub enum MenuAction {
     CopyRelativePath,
     Rename,
     Delete,
+    OpenExternal,
     Reveal,
     ChangeFolder,
     ChangeFolderTyped,
@@ -24,14 +25,23 @@ pub enum MenuEntry {
     Separator,
 }
 
-/// VS Code-style context menu for a tree row (`is_root` = a right-click on
-/// empty space, targeting the workspace root: creation only).
-pub fn menu_entries(is_root: bool) -> Vec<MenuEntry> {
+/// VS Code-style context menu for a tree row (`target` = `Some(is_dir)` for a
+/// row; `None` for a right-click on empty space, which targets the workspace
+/// root: creation only). "Open with Default App" is offered for files only —
+/// a directory's shell association is the file manager, which is what
+/// "Reveal in File Explorer" already does.
+pub fn menu_entries(target: Option<bool>) -> Vec<MenuEntry> {
     let mut entries = vec![
         MenuEntry::Action(MenuAction::NewFile, "New File…"),
         MenuEntry::Action(MenuAction::NewFolder, "New Folder…"),
     ];
-    if !is_root {
+    if target == Some(false) {
+        entries.extend([
+            MenuEntry::Separator,
+            MenuEntry::Action(MenuAction::OpenExternal, "Open with Default App"),
+        ]);
+    }
+    if target.is_some() {
         entries.extend([
             MenuEntry::Separator,
             MenuEntry::Action(MenuAction::CopyPath, "Copy Path"),
@@ -153,6 +163,32 @@ pub fn reveal(path: &Path) {
     }
 }
 
+/// Open a path with the OS-associated application (VS Code's "Open with
+/// Default App" / a double click in the file manager).
+///
+/// Windows goes through `explorer.exe <path>` rather than `cmd /c start`:
+/// explorer is a GUI-subsystem process, so no console is created for it and
+/// Windows 11 doesn't flash a Windows Terminal window (the same reason the
+/// [[events]] hooks use the windowless sidecar). It resolves the shell
+/// association exactly like a double click. Its exit code is unreliable
+/// (explorer routinely returns 1 on success), so only the spawn is checked.
+pub fn open_external(path: &Path) -> io::Result<()> {
+    #[cfg(windows)]
+    let program = "explorer";
+    #[cfg(target_os = "macos")]
+    let program = "open";
+    #[cfg(all(unix, not(target_os = "macos")))]
+    let program = "xdg-open";
+
+    std::process::Command::new(program)
+        .arg(path)
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .spawn()
+        .map(|_| ())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -164,14 +200,27 @@ mod tests {
         dir
     }
 
+    fn has(entries: &[MenuEntry], action: MenuAction) -> bool {
+        entries.iter().any(|e| matches!(e, MenuEntry::Action(a, _) if *a == action))
+    }
+
     #[test]
     fn menu_shape_for_rows_and_root() {
-        let row = menu_entries(false);
+        let row = menu_entries(Some(false));
         assert!(matches!(row[0], MenuEntry::Action(MenuAction::NewFile, _)));
-        assert!(row.iter().any(|e| matches!(e, MenuEntry::Action(MenuAction::Delete, _))));
-        let root = menu_entries(true);
-        assert!(!root.iter().any(|e| matches!(e, MenuEntry::Action(MenuAction::Rename, _))));
-        assert!(root.iter().any(|e| matches!(e, MenuEntry::Action(MenuAction::Reveal, _))));
+        assert!(has(&row, MenuAction::Delete));
+        let root = menu_entries(None);
+        assert!(!has(&root, MenuAction::Rename));
+        assert!(has(&root, MenuAction::Reveal));
+    }
+
+    #[test]
+    fn open_external_is_offered_for_files_only() {
+        assert!(has(&menu_entries(Some(false)), MenuAction::OpenExternal), "file row");
+        assert!(!has(&menu_entries(Some(true)), MenuAction::OpenExternal), "directory row");
+        assert!(!has(&menu_entries(None), MenuAction::OpenExternal), "empty space");
+        // Directories keep everything else they had.
+        assert!(has(&menu_entries(Some(true)), MenuAction::Rename));
     }
 
     #[test]

--- a/plugins/herdr-sidebar/src/explorer_app.rs
+++ b/plugins/herdr-sidebar/src/explorer_app.rs
@@ -573,7 +573,7 @@ impl App {
             let row = &self.rows[index];
             (row.path.clone(), row.is_dir)
         });
-        let entries = actions::menu_entries(target.is_none());
+        let entries = actions::menu_entries(target.as_ref().map(|(_, is_dir)| *is_dir));
         let selected = entries
             .iter()
             .position(|e| matches!(e, MenuEntry::Action(..)))
@@ -950,6 +950,14 @@ impl App {
             MenuAction::Delete => {
                 let Some((path, is_dir)) = target else { return };
                 self.overlay = Some(Overlay::ConfirmDelete { path, is_dir });
+            }
+            MenuAction::OpenExternal => {
+                let Some((path, _)) = target else { return };
+                let name = path.file_name().unwrap_or(path.as_os_str()).to_string_lossy();
+                self.notice = Some(match actions::open_external(&path) {
+                    Ok(()) => format!("opened: {name}"),
+                    Err(err) => format!("open failed: {err}"),
+                });
             }
             MenuAction::Reveal => {
                 let path = target.map(|(p, _)| p).unwrap_or_else(|| self.tree.root_path());
@@ -1647,7 +1655,7 @@ mod tests {
 
     #[test]
     fn menu_navigation_skips_separators_and_clamps() {
-        let entries = actions::menu_entries(false);
+        let entries = actions::menu_entries(Some(false));
         // First entry is an action; stepping up from it stays put.
         assert_eq!(step_menu(&entries, 0, -1), 0);
         // Stepping down over a separator lands on the next action.

--- a/plugins/herdr-sidebar/src/scm_app.rs
+++ b/plugins/herdr-sidebar/src/scm_app.rs
@@ -31,7 +31,7 @@ use herdr_sidebar::ui::{
     title_actions_visible, title_actions_width, truncate_to, within, wrap_footer_message,
     wrap_hints,
 };
-use herdr_sidebar::actions::{copy_to_clipboard, reveal};
+use herdr_sidebar::actions::{copy_to_clipboard, open_external, reveal};
 use herdr_sidebar::suggest;
 
 // VS Code's dark-theme git decoration colors.
@@ -343,6 +343,7 @@ enum MenuAction {
     Discard,
     CopyPath,
     CopyRelativePath,
+    OpenExternal,
     Reveal,
     // Drawer-line actions (commits, branches, stashes, remotes, tags).
     ShowRef,
@@ -1182,13 +1183,15 @@ impl App {
             _ => return, // section headers have no menu
         };
         let Some(entry) = entry.cloned() else { return };
-        let mut entries = vec![
-            MenuEntry::Action(MenuAction::OpenDiff, "Open Diff"),
-            MenuEntry::Action(
-                MenuAction::StageOrUnstage,
-                if staged { "Unstage Changes" } else { "Stage Changes" },
-            ),
-        ];
+        let mut entries = vec![MenuEntry::Action(MenuAction::OpenDiff, "Open Diff")];
+        // A deleted file has nothing left on disk to hand to the shell.
+        if entry.letter != 'D' {
+            entries.push(MenuEntry::Action(MenuAction::OpenExternal, "Open with Default App"));
+        }
+        entries.push(MenuEntry::Action(
+            MenuAction::StageOrUnstage,
+            if staged { "Unstage Changes" } else { "Stage Changes" },
+        ));
         if !staged {
             entries.push(MenuEntry::Action(MenuAction::Discard, "Discard Changes…"));
         }
@@ -1656,6 +1659,14 @@ impl App {
                 let rel = entry.path.replace('/', std::path::MAIN_SEPARATOR_STR);
                 let path = repo_root.unwrap_or_else(|| self.cwd.clone()).join(rel);
                 reveal(&path);
+            }
+            MenuAction::OpenExternal => {
+                let rel = entry.path.replace('/', std::path::MAIN_SEPARATOR_STR);
+                let path = repo_root.unwrap_or_else(|| self.cwd.clone()).join(&rel);
+                self.flash = Some(match open_external(&path) {
+                    Ok(()) => (format!("opened: {rel}"), false),
+                    Err(err) => (format!("open failed: {err}"), true),
+                });
             }
             _ => {}
         }


### PR DESCRIPTION
Ctrl+right-click on a file now offers handing it to the OS-associated application, the way a double click in the file manager would — the one thing the sidebar's preview pane can't do (images, PDFs, office documents, anything the terminal can't render).

### What's in the menu

- **Explorer** — `Open with Default App`, on **file rows only**. A directory's shell association *is* the file manager, which `Reveal in File Explorer` already covers, so directories and empty-space clicks are unchanged. `menu_entries` now takes `Option<bool>` (`Some(is_dir)`, or `None` for the workspace root) instead of a bare `is_root` flag.
- **Source Control** — same entry on file rows, hidden when the status letter is `D`: a deleted file has nothing left on disk to hand to the shell.

### `actions::open_external`

Windows goes through `explorer.exe <path>`, **not** `cmd /c start`: explorer is a GUI-subsystem process, so no console is created and Windows 11 never flashes a Windows Terminal window — the same reason the `[[events]]` hooks go through the windowless sidecar. macOS uses `open`, other unix `xdg-open`.

Explorer's exit code is unreliable (it routinely returns 1 on success), so only the **spawn** is reported, through the existing notice / flash line (`opened: <name>` / `open failed: <err>`).

### Verification

- `cargo build --release`, `cargo test` (79 + 9 pass, including a new `open_external_is_offered_for_files_only`), `cargo clippy --release -- -D warnings` — all clean on Windows.
- Live on Windows 11: a `.html` row launched the registered `ChromeHTML` handler with no console flash. An unregistered/broken association falls back to the shell's own "Open with" dialog, which is the correct shell behavior.

README and CLAUDE.md updated (the Windows `explorer.exe` rationale is captured next to the other Windows findings).

> Reminder for users hitting this menu for the first time: the sidebar's context menu needs `[ui] right_click_passthrough_modifier = "ctrl"` in herdr's `config.toml` — without it herdr keeps every right-click for its own pane menu.
