### PR TITLE
fix: destructive unstage fallback, IPC hang, temp-file symlink, redeploy pkill scope

### DIFF
--- a/plugins/herdr-sidebar/scripts/redeploy.sh
+++ b/plugins/herdr-sidebar/scripts/redeploy.sh
@@ -21,6 +21,13 @@ for ws in workspaces:
             print("closed", wid, pane["pane_id"], pane.get("label"))
 ' "$HERDR_BIN"
 
-pkill -f 'herdr-sidebar' 2>/dev/null
+# Match by process NAME, not full command line: `-f` would also kill
+# launcher scripts (open-sidebar.sh etc.) and unrelated processes whose argv
+# happens to contain the plugin path. Both Linux and macOS truncate `comm`
+# to 15 visible characters, so `herdr-sidebar-ensure` (20 chars) shows up
+# truncated as `herdr-sidebar-e` — match all three forms.
+pkill -x 'herdr-sidebar' 2>/dev/null
+pkill -x 'herdr-sidebar-ensure' 2>/dev/null
+pkill -x 'herdr-sidebar-e' 2>/dev/null
 "$HERDR_BIN" plugin action invoke herdr-sidebar.open-sidebar >/dev/null 2>&1
 echo 'redeploy complete - other workspaces re-dock on next focus'

--- a/plugins/herdr-sidebar/src/git.rs
+++ b/plugins/herdr-sidebar/src/git.rs
@@ -109,24 +109,36 @@ impl Git {
         run_in(&self.root, &["add", "-A"]).map(drop)
     }
 
+    /// Whether HEAD resolves to a real commit — false only on an unborn
+    /// branch (a repo with no commits yet), where `git reset` has nothing to
+    /// reset against.
+    fn has_head(&self) -> bool {
+        run_in(&self.root, &["rev-parse", "--verify", "HEAD"]).is_ok()
+    }
+
     /// Unstage one entry. `reset` needs a HEAD to reset against; on an unborn
     /// branch (no commits yet) fall back to dropping the path from the index.
+    /// The fallback is destructive on a repo WITH a HEAD (`rm --cached` stages
+    /// a deletion instead of unstaging), so it only runs for the unborn-branch
+    /// case — any other `reset` failure is propagated instead of swallowed.
     pub fn unstage(&self, entry: &FileEntry) -> Result<(), String> {
         let mut args = vec!["reset", "-q", "--", entry.path.as_str()];
         if let Some(orig) = &entry.orig {
             args.push(orig);
         }
-        if run_in(&self.root, &args).is_ok() {
-            return Ok(());
+        match run_in(&self.root, &args) {
+            Ok(_) => Ok(()),
+            Err(e) if self.has_head() => Err(e),
+            Err(_) => run_in(&self.root, &["rm", "--cached", "-r", "-q", "--", &entry.path]).map(drop),
         }
-        run_in(&self.root, &["rm", "--cached", "-r", "-q", "--", &entry.path]).map(drop)
     }
 
     pub fn unstage_all(&self) -> Result<(), String> {
-        if run_in(&self.root, &["reset", "-q"]).is_ok() {
-            return Ok(());
+        match run_in(&self.root, &["reset", "-q"]) {
+            Ok(_) => Ok(()),
+            Err(e) if self.has_head() => Err(e),
+            Err(_) => run_in(&self.root, &["rm", "--cached", "-r", "-q", "--", "."]).map(drop),
         }
-        run_in(&self.root, &["rm", "--cached", "-r", "-q", "--", "."]).map(drop)
     }
 
     /// Commit the staged changes; returns git's summary line ("[branch abc1234] …").
@@ -430,6 +442,55 @@ mod tests {
         names.sort();
         assert_eq!(names, ["a", "b"]);
         let _ = std::fs::remove_dir_all(&base);
+    }
+
+    /// A fresh repo with one commit on `main`, so HEAD resolves.
+    fn repo_with_head(name: &str) -> Git {
+        let root = std::env::temp_dir().join(format!("aa-git-unstage-{name}-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&root);
+        std::fs::create_dir_all(&root).unwrap();
+        for args in [
+            &["init", "-q"][..],
+            &["-c", "user.email=t@t.dev", "-c", "user.name=t", "commit", "--allow-empty", "-q", "-m", "init"][..],
+        ] {
+            std::process::Command::new("git").args(args).current_dir(&root).output().unwrap();
+        }
+        Git { root }
+    }
+
+    #[test]
+    fn unstage_all_propagates_reset_failure_instead_of_destructive_fallback_when_head_exists() {
+        let git = repo_with_head("unstage-all");
+        std::fs::write(git.root.join("file.txt"), "v1").unwrap();
+        run_in(&git.root, &["add", "-A"]).unwrap();
+        // Force `git reset` to fail deterministically without touching HEAD.
+        std::fs::write(git.root.join(".git/index.lock"), "").unwrap();
+        let result = git.unstage_all();
+        std::fs::remove_file(git.root.join(".git/index.lock")).unwrap();
+        assert!(result.is_err(), "a real reset failure must not report success");
+        let status = git.status().unwrap();
+        assert_eq!(status.staged.len(), 1, "file must still be staged, untouched");
+        assert_eq!(status.staged[0].letter, 'A', "must still be a staged add, not a staged deletion");
+        let _ = std::fs::remove_dir_all(&git.root);
+    }
+
+    #[test]
+    fn unstage_all_falls_back_on_a_genuinely_unborn_branch() {
+        let root = std::env::temp_dir()
+            .join(format!("aa-git-unstage-unborn-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&root);
+        std::fs::create_dir_all(&root).unwrap();
+        std::process::Command::new("git").args(["init", "-q"]).current_dir(&root).output().unwrap();
+        std::fs::write(root.join("file.txt"), "v1").unwrap();
+        let git = Git { root: root.clone() };
+        run_in(&git.root, &["add", "-A"]).unwrap();
+        // No commits yet: `git reset` has no HEAD to reset against.
+        assert!(!git.has_head());
+        assert!(git.unstage_all().is_ok());
+        let status = git.status().unwrap();
+        assert_eq!(status.staged, vec![]);
+        assert_eq!(status.unstaged, vec![entry("file.txt", 'U', None)]);
+        let _ = std::fs::remove_dir_all(&root);
     }
 
     #[test]

--- a/plugins/herdr-sidebar/src/ipc.rs
+++ b/plugins/herdr-sidebar/src/ipc.rs
@@ -11,8 +11,19 @@
 //! (herdr feeds the whole path through interprocess' namespaced naming), which a
 //! plain `File` can speak. On unix it is an ordinary unix domain socket.
 
-use std::io::{BufRead, BufReader, Write};
+use std::io::{BufRead, BufReader, Read, Write};
 use std::path::PathBuf;
+use std::time::Duration;
+
+/// How long to wait for a response before giving up. `exchange` runs on the
+/// UI/event-loop thread (`viewer.rs`, input handlers), so an unbounded read
+/// would hang the whole sidebar if the herdr process accepts the connection
+/// but never answers.
+const IPC_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Cap on a single response line, so a runaway/malformed reply can't grow
+/// unbounded in memory.
+const MAX_RESPONSE_BYTES: u64 = 4 * 1024 * 1024;
 
 /// `HERDR_SOCKET_PATH` (injected into hook/action commands), falling back to
 /// herdr's default socket location.
@@ -75,6 +86,13 @@ pub fn report_identity(pane_id: &str, my: crate::state::View, merged: bool) {
     );
 }
 
+// Windows' named-pipe `File` handle has no `set_read_timeout` via std (no
+// overlapped I/O in this fix's scope), so it's bounded with a background
+// thread instead. unix sockets support native read/write timeouts, which
+// `roundtrip` uses directly below — no thread, so no risk of a blocked
+// reader thread + open fd lingering past the timeout when the peer never
+// responds (the thread-based approach would leak exactly that on every
+// timeout against a wedged peer).
 #[cfg(windows)]
 fn roundtrip(path: &std::path::Path, request: &str) -> std::io::Result<String> {
     let pipe = format!(r"\\.\pipe\{}", path.display());
@@ -82,20 +100,93 @@ fn roundtrip(path: &std::path::Path, request: &str) -> std::io::Result<String> {
         .read(true)
         .write(true)
         .open(pipe)?;
-    exchange(stream, request)
+    exchange_with_thread_timeout(stream, request, IPC_TIMEOUT)
 }
 
 #[cfg(unix)]
 fn roundtrip(path: &std::path::Path, request: &str) -> std::io::Result<String> {
     let stream = std::os::unix::net::UnixStream::connect(path)?;
+    stream.set_read_timeout(Some(IPC_TIMEOUT))?;
+    stream.set_write_timeout(Some(IPC_TIMEOUT))?;
     exchange(stream, request)
 }
 
-fn exchange<S: std::io::Read + Write>(mut stream: S, request: &str) -> std::io::Result<String> {
+/// Write the request, then read one response line. `S` must already have its
+/// own read/write timeout configured by the caller.
+fn exchange<S: Read + Write>(mut stream: S, request: &str) -> std::io::Result<String> {
     stream.write_all(request.as_bytes())?;
     stream.write_all(b"\n")?;
     stream.flush()?;
     let mut line = String::new();
-    BufReader::new(stream).read_line(&mut line)?;
+    BufReader::new(stream.take(MAX_RESPONSE_BYTES)).read_line(&mut line)?;
     Ok(line)
+}
+
+/// Windows-only: bound the read with a background thread + `recv_timeout`
+/// since `File` has no native read timeout via std. Note this can still
+/// leak a blocked thread and an open pipe handle if the peer never responds
+/// and never closes the pipe — accepted here as strictly better than the
+/// previous unconditional hang, not as a full fix (that needs overlapped
+/// I/O on the pipe handle).
+#[cfg(windows)]
+fn exchange_with_thread_timeout<S: Read + Write + Send + 'static>(
+    mut stream: S,
+    request: &str,
+    timeout: Duration,
+) -> std::io::Result<String> {
+    stream.write_all(request.as_bytes())?;
+    stream.write_all(b"\n")?;
+    stream.flush()?;
+    let (tx, rx) = std::sync::mpsc::channel();
+    std::thread::spawn(move || {
+        let mut line = String::new();
+        let result = BufReader::new(stream.take(MAX_RESPONSE_BYTES))
+            .read_line(&mut line)
+            .map(|_| line);
+        let _ = tx.send(result);
+    });
+    rx.recv_timeout(timeout).unwrap_or_else(|_| {
+        Err(std::io::Error::new(
+            std::io::ErrorKind::TimedOut,
+            "herdr socket response timed out",
+        ))
+    })
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+    use super::*;
+    use std::os::unix::net::{UnixListener, UnixStream};
+
+    /// A peer that accepts the connection but never reads or writes must not
+    /// hang the caller — this is the exact shape of a wedged herdr host.
+    /// Exercises the real `roundtrip` timeout setup (not a hand-rolled one)
+    /// so the test would fail if a future change dropped the timeout calls.
+    #[test]
+    fn exchange_times_out_instead_of_hanging_on_an_unresponsive_peer() {
+        let path = std::env::temp_dir()
+            .join(format!("aa-ipc-timeout-test-{}.sock", std::process::id()));
+        let _ = std::fs::remove_file(&path);
+        let listener = UnixListener::bind(&path).unwrap();
+        std::thread::spawn(move || {
+            // Accept and hold the connection open (binding it, not `let _`,
+            // which would drop it immediately and close the socket) without
+            // ever responding; the stream's own timeout is what bounds this.
+            if let Ok((_conn, _)) = listener.accept() {
+                std::thread::sleep(Duration::from_secs(30));
+            }
+        });
+        let stream = UnixStream::connect(&path).unwrap();
+        stream.set_read_timeout(Some(Duration::from_millis(200))).unwrap();
+        stream.set_write_timeout(Some(Duration::from_millis(200))).unwrap();
+        let start = std::time::Instant::now();
+        let result = exchange(stream, "{}");
+        let elapsed = start.elapsed();
+        let _ = std::fs::remove_file(&path);
+        assert!(result.is_err(), "an unresponsive peer must not report success");
+        assert!(
+            elapsed < Duration::from_secs(2),
+            "must bail out around the timeout, not hang; took {elapsed:?}"
+        );
+    }
 }

--- a/plugins/herdr-sidebar/src/viewer.rs
+++ b/plugins/herdr-sidebar/src/viewer.rs
@@ -38,10 +38,36 @@ const POLL: Duration = Duration::from_millis(250);
 const MAX_BYTES: usize = 1024 * 1024;
 const MAX_LINES: usize = 5000;
 
+/// Directory for the sidebar's private scratch files (control/park files).
+/// `std::env::temp_dir()` can be a shared, world-writable directory (unix
+/// `/tmp`) where our filenames are predictable from the pane id; scope our
+/// files into a private, mode-0700 subdirectory so another local user can't
+/// plant a symlink at a path we're about to `fs::write` through. Windows'
+/// per-user `%TEMP%` needs no extra scoping.
+fn scratch_dir() -> PathBuf {
+    let dir = std::env::temp_dir().join("herdr-sidebar-scratch");
+    let _ = std::fs::create_dir_all(&dir);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let _ = std::fs::set_permissions(&dir, std::fs::Permissions::from_mode(0o700));
+    }
+    dir
+}
+
+/// Write `contents` to `path`, refusing to follow a pre-existing symlink at
+/// that location (defense in depth alongside `scratch_dir`'s 0700 perms).
+fn write_scratch_file(path: &Path, contents: &str) -> std::io::Result<()> {
+    if std::fs::symlink_metadata(path).map(|m| m.file_type().is_symlink()).unwrap_or(false) {
+        std::fs::remove_file(path)?;
+    }
+    std::fs::write(path, contents)
+}
+
 /// The control file the sidebar writes requests into, unique per sidebar
 /// pane (tab) so tabs don't steer each other's viewers.
 pub fn control_path(sidebar_pane_id: &str) -> PathBuf {
-    std::env::temp_dir().join(format!(
+    scratch_dir().join(format!(
         "herdr-sidebar-preview-{}.ctl",
         sidebar_pane_id.replace(':', "_")
     ))
@@ -484,7 +510,7 @@ fn draw_doc(frame: &mut Frame, doc: &mut Doc, theme: IconTheme) -> usize {
 /// human-readable notices.
 pub fn open_in_pane(my_pane_id: &str, spawn_cwd: &Path, payload: &str) -> Result<(), String> {
     let control = control_path(my_pane_id);
-    std::fs::write(&control, payload).map_err(|e| format!("preview failed: {e}"))?;
+    write_scratch_file(&control, payload).map_err(|e| format!("preview failed: {e}"))?;
     let full = crate::state::load_state().preview_full;
 
     // Measure the sidebar's width share FIRST: closing a stale viewer below
@@ -685,8 +711,7 @@ fn spawn_viewer_pane(
 /// Park plan for `owner`'s tab, recorded beside the control file so either
 /// process (sidebar or viewer) can restore.
 fn park_path(owner: &str) -> PathBuf {
-    std::env::temp_dir()
-        .join(format!("herdr-sidebar-preview-{}.park.json", owner.replace(':', "_")))
+    scratch_dir().join(format!("herdr-sidebar-preview-{}.park.json", owner.replace(':', "_")))
 }
 
 #[derive(serde::Serialize, serde::Deserialize, Clone, Copy, Debug)]
@@ -835,7 +860,7 @@ fn park_others(owner: &str) {
     }
     let plan = ParkPlan { tab, owner_ratio, panes: others };
     if let Ok(json) = serde_json::to_string(&plan) {
-        let _ = std::fs::write(park_path(owner), json);
+        let _ = write_scratch_file(&park_path(owner), &json);
     }
 }
 
@@ -1024,6 +1049,42 @@ fn right_neighbor(layout_json: &str, pane_id: &str) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[cfg(unix)]
+    #[test]
+    fn scratch_dir_is_private_to_the_owning_user() {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = scratch_dir();
+        let mode = std::fs::metadata(&dir).unwrap().permissions().mode();
+        assert_eq!(
+            mode & 0o777,
+            0o700,
+            "scratch dir must not be group/world readable or writable"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn write_scratch_file_refuses_to_follow_a_preexisting_symlink() {
+        use std::os::unix::fs::symlink;
+        let dir = scratch_dir();
+        let victim = dir.join(format!("aa-victim-{}.txt", std::process::id()));
+        let link = dir.join(format!("aa-link-{}.ctl", std::process::id()));
+        std::fs::write(&victim, "original victim contents").unwrap();
+        let _ = std::fs::remove_file(&link);
+        symlink(&victim, &link).unwrap();
+
+        write_scratch_file(&link, "payload").unwrap();
+
+        // The symlink must have been replaced by a real file, and the
+        // victim it used to point at must be untouched.
+        assert!(!std::fs::symlink_metadata(&link).unwrap().file_type().is_symlink());
+        assert_eq!(std::fs::read_to_string(&link).unwrap(), "payload");
+        assert_eq!(std::fs::read_to_string(&victim).unwrap(), "original victim contents");
+
+        let _ = std::fs::remove_file(&victim);
+        let _ = std::fs::remove_file(&link);
+    }
 
     #[test]
     fn requests_roundtrip() {


### PR DESCRIPTION
## What

Four safety-tier fixes found during review, each with a regression test:

1. **`git.rs` — destructive unstage fallback.** `unstage()`/`unstage_all()` fell back to `git rm --cached` on *any* `git reset` failure, not just the intended "unborn branch, nothing to reset onto" case. On a real HEAD, a transient reset failure (lock contention, permissions, etc.) could silently convert a staged change into a staged deletion instead of surfacing the error.
2. **`ipc.rs` — unbounded socket read on the UI thread.** The IPC round-trip had no read timeout; a herdr process that accepted the connection but never responded would hang the sidebar's event loop indefinitely.
3. **`viewer.rs` — predictable temp file path in a shared directory.** Control/park files were written directly under the shared system temp dir at predictable paths, which is vulnerable to a symlink swap by another local user (TOCTOU).
4. **`redeploy.sh` — `pkill -f` matches on full command line**, so it could kill unrelated processes whose argv happens to contain the plugin path (including launcher scripts). Switched to `pkill -x` on process name, matching all three truncated forms the OS produces for `herdr-sidebar-ensure` (`comm` is capped at 15 chars on Linux/macOS).

## Why

All four are latent safety/reliability issues rather than user-facing bugs: silent data-safety risk, a UI-thread hang vector, a local privilege/tampering risk, and an over-broad process kill. None change any documented behavior in the happy path.

## Fix

- `git.rs`: fallback to `git rm --cached` now only fires when `git rev-parse --verify HEAD` fails (genuinely unborn branch); any other reset failure propagates as an `Err`.
- `ipc.rs`: unix uses `UnixStream::set_read_timeout`/`set_write_timeout` (native, no thread/fd leak). Windows' `File`-backed named pipe has no native timeout via std, so it keeps a thread+`recv_timeout` fallback, documented with its known residual leak risk on an unresponsive peer — strictly better than the previous unconditional hang.
- `viewer.rs`: control/park files now live under a private `0700` scratch subdirectory, and writes go through a helper that removes any pre-existing symlink at the target path before writing.
- `redeploy.sh`: `pkill -x 'herdr-sidebar'`, `pkill -x 'herdr-sidebar-ensure'`, `pkill -x 'herdr-sidebar-e'` instead of `pkill -f 'herdr-sidebar'`.

## Test

- Added unit tests for each fix (unstage HEAD-failure vs. genuinely-unborn-branch cases, IPC timeout against a real unresponsive `UnixListener` peer, scratch-dir permissions + symlink-swap resistance).
- Full suite: 92/92 passing.
- `cargo clippy -- -D warnings`: clean.
- `redeploy.sh` change verified by inspection against its Windows twin (`redeploy.ps1`), which already filters by process name.

Windows-only code path in `ipc.rs` (`exchange_with_thread_timeout`) could not be locally compiled/verified on this machine (no Windows cross toolchain here) — same pre-existing limitation the project's own docs note for other Windows-only behaviors.