### PR TITLE
v0.8.1: stop Unix focus-hook replace loop

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -872,6 +872,11 @@ First clean install of both plugins on a Mac (driven over SSH), findings:
   They now take the SAME `herdr-sidebar-ensure.lock` mkdir lock as the hook — waiting
   (20×0.5s) instead of yielding so the toggle isn't dropped. Post-lock terminal commands
   must NOT `exec`: exec skips the EXIT trap and leaks the lock until the 30s stale-break.
+- **Unix ensure must hold its lock through the first TUI token stamp**: left-docking calls
+  `pane swap` and restores focus, and both operations re-emit focus events. Releasing the
+  lock immediately after `pane run` exposes a label-only pane that the corpse rule replaces,
+  creating an unbounded close/spawn loop (issue #29). Poll the new pane's identity token while
+  locked, matching the Windows ensure; do not replace this with a fixed startup sleep.
 - The `merged` (unified sidebar) default was still `false` from the experiment era — fresh
   installs came up as a pinned separate Explorer. Flipped to `true` (existing users keep
   their persisted value).

--- a/plugins/herdr-sidebar/Cargo.lock
+++ b/plugins/herdr-sidebar/Cargo.lock
@@ -550,7 +550,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "herdr-sidebar"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "crossterm",
  "ratatui",

--- a/plugins/herdr-sidebar/Cargo.toml
+++ b/plugins/herdr-sidebar/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "herdr-sidebar"
-version = "0.8.0"
+version = "0.8.1"
 edition = "2024"
 description = "VS Code-style sidebar for herdr: file explorer + source control in one pane"
 license = "MIT"

--- a/plugins/herdr-sidebar/herdr-plugin.toml
+++ b/plugins/herdr-sidebar/herdr-plugin.toml
@@ -18,7 +18,7 @@
 
 id = "herdr-sidebar"
 name = "herdr-sidebar"
-version = "0.8.0"
+version = "0.8.1"
 description = "VS Code-style sidebar: file explorer + source control (with ✧ AI commit messages) in one herdr pane."
 min_herdr_version = "0.8.0"
 platforms = ["linux", "macos", "windows"]
@@ -96,9 +96,9 @@ command = ["powershell", "-NoProfile", "-ExecutionPolicy", "Bypass", "-File", "s
 # metadata tokens do not) sitting unhealed until the user switched tabs.
 # pane.focused heals resumed corpses the moment the user interacts with the
 # restored session (client attach emits no tab/workspace events at all).
-# Hooking pane.* from a pane-creating script is only safe because open()
-# holds its lock until the spawned TUI stamps its token — queued invocations
-# then observe a LIVE pane and no-op instead of replace-looping.
+# Hooking pane.* from a pane-creating script is only safe because the ensure
+# holds its lock until the spawned TUI stamps its token — re-entrant focus
+# invocations skip while locked, and later ones observe a LIVE pane.
 [[events]]
 on = "pane.focused"
 platforms = ["linux", "macos"]

--- a/plugins/herdr-sidebar/scripts/ensure-sidebar.sh
+++ b/plugins/herdr-sidebar/scripts/ensure-sidebar.sh
@@ -105,6 +105,18 @@ fi
 "$herdr_bin" pane run "$np" "herdr-sidebar"
 "$herdr_bin" pane rename "$np" Explorer >/dev/null 2>&1 || true
 
+# Keep the ensure lock through the TUI's first identity stamp. The swap and
+# focus calls above/below emit fresh focus events; without this wait, one can
+# see the new label before its token, classify the pane as a resumed corpse,
+# and replace it forever (issue #29). Six seconds matches the Windows ensure.
+for _ in {1..30}; do
+  current_panes="$("$herdr_bin" pane list 2>/dev/null || true)"
+  if [ "$(printf '%s' "$current_panes" | "$bin" --pane-has-token "$np" 2>/dev/null || true)" = "yes" ]; then
+    break
+  fi
+  sleep 0.2
+done
+
 # Hand focus back if the swap left it on the explorer (focus follows the slot).
 if [ "$needs_swap" = "true" ] && [ "$target" = "$fid" ]; then
   "$herdr_bin" pane focus --direction right --pane "$np" >/dev/null 2>&1 || true

--- a/plugins/herdr-sidebar/src/launch.rs
+++ b/plugins/herdr-sidebar/src/launch.rs
@@ -1017,6 +1017,19 @@ mod tests {
     }
 
     #[test]
+    fn pane_token_probe_distinguishes_starting_and_live_sidebars() {
+        let starting = pane_list(
+            r#"{"pane_id":"w1:p1","tab_id":"w1:t1","label":"Explorer","tokens":{}}"#,
+        );
+        let live = pane_list(
+            r#"{"pane_id":"w1:p1","tab_id":"w1:t1","label":"Explorer","tokens":{"herdr-sidebar-explorer":"100"}}"#,
+        );
+        assert!(!pane_has_token(&starting, "w1:p1"));
+        assert!(pane_has_token(&live, "w1:p1"));
+        assert!(!pane_has_token(&live, "w1:p2"));
+    }
+
+    #[test]
     fn decision_replaces_dead_panes() {
         // Stale heartbeat (or a pre-heartbeat token shape) = a dead TUI whose
         // pane must be closed and re-docked, never focused.

--- a/plugins/herdr-sidebar/src/main.rs
+++ b/plugins/herdr-sidebar/src/main.rs
@@ -49,6 +49,12 @@ fn main() -> std::io::Result<()> {
             println!("{}", launch::focused_pane_in(&read_stdin()?, &scope));
             return Ok(());
         }
+        Some("--pane-has-token") => {
+            let pane_id = std::env::args().nth(2).unwrap_or_default();
+            let present = launch::pane_has_token(&read_stdin()?, &pane_id);
+            println!("{}", if present { "yes" } else { "no" });
+            return Ok(());
+        }
         Some("--event-scope") => {
             let payload = std::env::var("HERDR_PLUGIN_EVENT_JSON").unwrap_or_default();
             println!("{}", launch::event_scope(&payload));
@@ -98,7 +104,7 @@ fn main() -> std::io::Result<()> {
         Some(other) => {
             eprintln!("herdr-sidebar: unknown argument `{other}`");
             eprintln!(
-                "usage: herdr-sidebar [--view explorer|git|--preview [ctl]|--launch-decision [git]|--focused-pane|--open-plan|--focused-tab|--auto-open|--dock-right]"
+                "usage: herdr-sidebar [--view explorer|git|--preview [ctl]|--launch-decision [git]|--focused-pane|--pane-has-token <id>|--open-plan|--focused-tab|--auto-open|--dock-right]"
             );
             std::process::exit(2);
         }


### PR DESCRIPTION
## Summary
- hold the Unix ensure lock until the spawned sidebar reports its identity token
- prevent left-dock focus events from replacing a still-starting pane in a loop
- add a tested token-probe helper and document the invariant
- bump the plugin to v0.8.1

Fixes #29.

Thanks @jesuith1 for the detailed reproduction and root-cause analysis.

## Validation
- cargo test (182 library + 17 binary tests)
- cargo build --release
- cargo clippy --release -- -D warnings
- bash -n scripts/ensure-sidebar.sh scripts/open-sidebar.sh scripts/open-git.sh
- independent Coordinator-claude review: no blockers