### PR TITLE
Sidebar width and preview lifecycle fixes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -365,6 +365,11 @@ HACKING.md — budget time for that before promising a patched build.
   identity token itself, synchronously, right after `pane.split` and BEFORE
   `pane run` — there is then no token-less window at all, so no wait/poll is
   needed. Worth adopting if the launchers are ever reworked.
+- A focus event may yield when the ensure lock is held because another focus event follows, but
+  `tab.created` is discrete. Unix AND the Windows sidecar must wait for the lock (the same
+  20 × 0.5 s budget as a manual toggle), or a preview tab created during the first-token wait
+  can permanently miss its sidebar (issue #32). Herdr's `EventEnvelope` serializes the JSON
+  discriminator as `tab_created`; manifest hook names remain dotted (`tab.created`).
 - **Stamp the heartbeat on EVERY event-loop iteration, not only in the poll-timeout
   branch**: sustained input with <500ms gaps (held-key auto-repeat, a long paste) keeps
   `event::poll` returning true, starving a timeout-branch heartbeat until the launcher
@@ -391,6 +396,10 @@ HACKING.md — budget time for that before promising a patched build.
   forwards it via the `env` param (`state::spawn_env`). Legacy
   `%APPDATA%\herdr\aa-sidebar.json` is migrated on first load. A fresh sidebar opens on
   the last-active view.
+- Sidebar width is a persisted column target (32 by default, 24–80 in 4-column steps), not
+  a frozen split ratio. A change to the whole tab area re-applies it through the ratio-aware
+  resize path; a pane-only divider resize is respected for the current layout instead of
+  snapping back. The existing 15%–50% share bounds still win at extreme tab widths.
 - Every Settings action uses `state::update_state`, a lock-protected read-modify-write.
   Never write an app's startup snapshot wholesale: preview tabs run independent sidebar
   processes, and a stale snapshot silently reverts newer settings from another tab.
@@ -675,6 +684,10 @@ setting are all gone.
   selects rendered text, Shift+click extends it, and Ctrl/Cmd+C copies it. Selection preserves
   syntax/diff styling on screen, omits file line-number gutters, and does not insert newlines at
   visual wrap boundaries.
+- Preview return focus is durable pane metadata (`hs-preview-origin-tab`), not
+  `PreviewTarget.tab_id` (that is the preview tab itself). Reusing an ephemeral preview from
+  its own sidebar preserves the original origin; focus it before closing because closing the
+  current tab can kill the viewer before any follow-up IPC runs.
 
 ### Syntax highlighting (file preview)
 
@@ -706,6 +719,9 @@ setting are all gone.
 - Clipboard is best-effort and command-backed: `clip` / PowerShell `Get-Clipboard` on
   Windows, `pbcopy`/`pbpaste` on macOS, and wl-clipboard or xclip on Linux. Ctrl and Cmd
   shortcuts are both accepted; CONTROL+ALT chars remain text so Windows AltGr layouts work.
+  A copy command counts only when its exit status succeeds. Do not treat writing OSC 52 bytes
+  as confirmed clipboard success: terminals provide no acknowledgement here, and unconditional
+  escape output would add a behavior/security compatibility change with no opt-out.
 - Edit mode accepts terminal mouse input: click moves the caret, drag selects across logical and
   wrapped rows, and Shift+click extends the current selection. Coordinates account for the line
   number gutter, tabs, wide Unicode cells, and the editor's wrapped-row scroll offset.

--- a/README.md
+++ b/README.md
@@ -57,7 +57,8 @@ A real tree, not a directory dump:
   mirroring the tree you clicked from. Your terminals are never moved. The tab is
   *ephemeral* (labelled `name · preview`), so clicking another file reuses it; **double-click**
   to pin it and the next file gets a fresh tab. Click a file that is already open and
-  you jump to its tab instead of opening it twice. Line numbers, scrolling,
+  you jump to its tab instead of opening it twice. Closing a preview returns to the tab
+  that opened it. Line numbers, scrolling,
   binary-safe, and **long lines wrap** — press `w` to switch wrapping off for the
   document you are reading.
 - **Experimental in-pane editing** — press `e` in a regular UTF-8 file preview. The editor
@@ -91,6 +92,8 @@ A real tree, not a directory dump:
   closed until you invoke the open-sidebar action yourself.
 - Prefer the tree on the other side? Toggle "Dock on the right" in ⚙ Settings; the choice
   persists for every future launch and auto-docked tab.
+- Prefer a different width? Adjust "Sidebar width" with `←`/`→` in ⚙ Settings. The column
+  target persists and is re-applied when the surrounding tab width changes.
 
 ### 🔀 Source Control
 
@@ -133,7 +136,7 @@ The ⚙ settings modal — mouse-toggleable like everything else — flips betwe
 <img src="plugins/herdr-sidebar/docs/media/settings.png" alt="The settings modal" width="920">
 </div>
 
-Dock side, icon theme, dotfile visibility, live-folder following, and the full hotkey
+Dock side, sidebar width, icon theme, dotfile visibility, live-folder following, and the full hotkey
 reference live in the same modal (with a toggle if you'd rather keep the key hints
 pinned to the sidebar's footer), and every choice persists across restarts. However you
 split it, the dock takes care of itself: a focus hook re-docks the sidebar in any tab or

--- a/plugins/herdr-sidebar/Cargo.lock
+++ b/plugins/herdr-sidebar/Cargo.lock
@@ -550,7 +550,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "herdr-sidebar"
-version = "0.8.1"
+version = "0.9.0"
 dependencies = [
  "crossterm",
  "ratatui",

--- a/plugins/herdr-sidebar/Cargo.toml
+++ b/plugins/herdr-sidebar/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "herdr-sidebar"
-version = "0.8.1"
+version = "0.9.0"
 edition = "2024"
 description = "VS Code-style sidebar for herdr: file explorer + source control in one pane"
 license = "MIT"

--- a/plugins/herdr-sidebar/herdr-plugin.toml
+++ b/plugins/herdr-sidebar/herdr-plugin.toml
@@ -18,7 +18,7 @@
 
 id = "herdr-sidebar"
 name = "herdr-sidebar"
-version = "0.8.1"
+version = "0.9.0"
 description = "VS Code-style sidebar: file explorer + source control (with ✧ AI commit messages) in one herdr pane."
 min_herdr_version = "0.8.0"
 platforms = ["linux", "macos", "windows"]

--- a/plugins/herdr-sidebar/scripts/ensure-sidebar.sh
+++ b/plugins/herdr-sidebar/scripts/ensure-sidebar.sh
@@ -18,17 +18,32 @@ bin="$bin_dir/herdr-sidebar"
 # lock so a disabled hook never contends with a user toggle.
 [ "$("$bin" --auto-open 2>/dev/null || echo on)" = "off" ] && exit 0
 
-# Focus events arrive in bursts (tab.focused + workspace.focused for one switch)
-# and concurrent ensures each open an explorer — serialize with an atomic mkdir
-# lock. Losing the race skips this ensure; the next focus event re-fires it.
+# Focus events arrive in bursts and concurrent ensures each open an explorer —
+# serialize with an atomic mkdir lock. Focus events may skip a held lock because
+# another event will follow; tab.created is discrete and must wait or the new
+# preview tab can permanently miss its sidebar (issue #32).
 lock_dir="${TMPDIR:-/tmp}/herdr-sidebar-ensure.lock"
+event_kind="$("$bin" --event-kind 2>/dev/null || true)"
 if ! mkdir "$lock_dir" 2>/dev/null; then
-  # Break locks older than 30s (a crashed ensure), otherwise yield.
+  # Break locks older than 30s (a crashed ensure).
   now="$(date +%s)"
   born="$(stat -c %Y "$lock_dir" 2>/dev/null || stat -f %m "$lock_dir" 2>/dev/null || echo "$now")"
-  [ $((now - born)) -gt 30 ] || exit 0
-  rm -rf "$lock_dir" 2>/dev/null
-  mkdir "$lock_dir" 2>/dev/null || exit 0
+  if [ $((now - born)) -gt 30 ]; then
+    rm -rf "$lock_dir" 2>/dev/null
+    mkdir "$lock_dir" 2>/dev/null || exit 0
+  elif [ "$event_kind" = "tab_created" ]; then
+    acquired="false"
+    for _ in {1..20}; do
+      sleep 0.5
+      if mkdir "$lock_dir" 2>/dev/null; then
+        acquired="true"
+        break
+      fi
+    done
+    [ "$acquired" = "true" ] || exit 0
+  else
+    exit 0
+  fi
 fi
 trap 'rmdir "$lock_dir" 2>/dev/null' EXIT
 

--- a/plugins/herdr-sidebar/src/actions.rs
+++ b/plugins/herdr-sidebar/src/actions.rs
@@ -126,7 +126,6 @@ pub fn delete(path: &Path, is_dir: bool) -> io::Result<()> {
 /// Copy text to the system clipboard by piping to the platform's clipboard
 /// tool (a console child of the TUI's own pty — no window is created).
 pub fn copy_to_clipboard(text: &str) -> io::Result<()> {
-    use std::io::Write;
     #[cfg(windows)]
     let candidates: &[&[&str]] = &[&["clip"]];
     #[cfg(not(windows))]
@@ -134,24 +133,37 @@ pub fn copy_to_clipboard(text: &str) -> io::Result<()> {
 
     let mut last_err = io::Error::new(io::ErrorKind::NotFound, "no clipboard tool found");
     for argv in candidates {
-        let spawned = std::process::Command::new(argv[0])
-            .args(&argv[1..])
-            .stdin(std::process::Stdio::piped())
-            .stdout(std::process::Stdio::null())
-            .stderr(std::process::Stdio::null())
-            .spawn();
-        match spawned {
-            Ok(mut child) => {
-                if let Some(stdin) = child.stdin.as_mut() {
-                    stdin.write_all(text.as_bytes())?;
-                }
-                child.wait()?;
-                return Ok(());
-            }
+        match copy_with(argv, text) {
+            Ok(()) => return Ok(()),
             Err(err) => last_err = err,
         }
     }
     Err(last_err)
+}
+
+fn copy_with(argv: &[&str], text: &str) -> io::Result<()> {
+    use std::io::Write;
+
+    let mut child = std::process::Command::new(argv[0])
+        .args(&argv[1..])
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .spawn()?;
+    let Some(mut stdin) = child.stdin.take() else {
+        return Err(io::Error::new(
+            io::ErrorKind::BrokenPipe,
+            format!("{} opened without stdin", argv[0]),
+        ));
+    };
+    stdin.write_all(text.as_bytes())?;
+    drop(stdin);
+    let status = child.wait()?;
+    if status.success() {
+        Ok(())
+    } else {
+        Err(io::Error::other(format!("{} exited with {status}", argv[0])))
+    }
 }
 
 /// Read text from the system clipboard when a platform clipboard command is
@@ -351,6 +363,16 @@ mod tests {
         assert_eq!(validate_name("a\\b"), None);
         assert_eq!(validate_name("C:"), None);
         assert_eq!(validate_name(".."), None);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn clipboard_commands_must_accept_input_and_exit_successfully() {
+        assert!(copy_with(&["sh", "-c", "cat >/dev/null"], "copied").is_ok());
+        let error = copy_with(&["sh", "-c", "cat >/dev/null; exit 7"], "not copied")
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("exited with"), "{error}");
     }
 
     #[test]

--- a/plugins/herdr-sidebar/src/ensure.rs
+++ b/plugins/herdr-sidebar/src/ensure.rs
@@ -13,22 +13,31 @@ use crate::{ipc, launch};
 struct Lock(PathBuf);
 
 impl Lock {
-    fn acquire() -> Option<Self> {
+    fn acquire(wait: bool) -> Option<Self> {
         let dir = std::env::temp_dir().join("herdr-sidebar-ensure.lock");
-        if std::fs::create_dir(&dir).is_ok() {
-            return Some(Self(dir));
+        let attempts = if wait { 20 } else { 0 };
+        for attempt in 0..=attempts {
+            if std::fs::create_dir(&dir).is_ok() {
+                return Some(Self(dir));
+            }
+            // Break locks older than 30s (a crashed run), otherwise yield or
+            // wait for a discrete action that must not be dropped.
+            let stale = std::fs::metadata(&dir)
+                .and_then(|m| m.created().or_else(|_| m.modified()))
+                .ok()
+                .and_then(|t| t.elapsed().ok())
+                .is_some_and(|age| age.as_secs() > 30);
+            if stale {
+                let _ = std::fs::remove_dir_all(&dir);
+                if std::fs::create_dir(&dir).is_ok() {
+                    return Some(Self(dir));
+                }
+            }
+            if attempt < attempts {
+                std::thread::sleep(std::time::Duration::from_millis(500));
+            }
         }
-        // Break locks older than 30s (a crashed run), otherwise yield.
-        let stale = std::fs::metadata(&dir)
-            .and_then(|m| m.created().or_else(|_| m.modified()))
-            .ok()
-            .and_then(|t| t.elapsed().ok())
-            .is_some_and(|age| age.as_secs() > 30);
-        if !stale {
-            return None;
-        }
-        let _ = std::fs::remove_dir_all(&dir);
-        std::fs::create_dir(&dir).ok().map(|_| Self(dir))
+        None
     }
 }
 
@@ -50,7 +59,9 @@ pub fn run(toggle: bool) -> std::io::Result<()> {
     if !toggle && !crate::state::load_state().auto_open {
         return Ok(());
     }
-    let Some(_lock) = Lock::acquire() else {
+    let event_json = std::env::var("HERDR_PLUGIN_EVENT_JSON").unwrap_or_default();
+    let wait_for_lock = must_wait_for_lock(toggle, &event_json);
+    let Some(_lock) = Lock::acquire(wait_for_lock) else {
         return Ok(());
     };
     let mut panes = ipc::call_text("pane.list", serde_json::json!({}))?;
@@ -62,7 +73,7 @@ pub fn run(toggle: bool) -> std::io::Result<()> {
     let scope = if toggle {
         String::new()
     } else {
-        launch::event_scope(&std::env::var("HERDR_PLUGIN_EVENT_JSON").unwrap_or_default())
+        launch::event_scope(&event_json)
     };
     let tab = snooze_tab_for_scope(&panes, &scope);
     let snooze_dir = snooze::dir();
@@ -127,9 +138,10 @@ fn open(panes_json: &str, focus_new: bool, scope: &str) -> std::io::Result<()> {
         return Ok(());
     };
 
-    let dock_right = crate::state::load_state().dock_right;
+    let state = crate::state::load_state();
+    let dock_right = state.dock_right;
     let layout = ipc::call_text("pane.layout", serde_json::json!({ "pane_id": fid }))?;
-    let plan = launch::open_plan(&layout, dock_right);
+    let plan = launch::open_plan(&layout, dock_right, state.sidebar_width);
     let mut fields = plan.split('\t');
     let target = fields
         .next()
@@ -281,4 +293,16 @@ mod tests {
         assert_eq!(snooze_tab_for_scope(panes, "w2:t1"), "w2:t1");
         assert_eq!(snooze_tab_for_scope(panes, "w2"), "");
     }
+
+    #[test]
+    fn discrete_tab_creation_and_manual_toggles_wait_for_the_lock() {
+        assert!(must_wait_for_lock(false, r#"{"event":"tab_created"}"#));
+        assert!(must_wait_for_lock(false, r#"{"event":"tab.created"}"#));
+        assert!(must_wait_for_lock(true, ""));
+        assert!(!must_wait_for_lock(false, r#"{"event":"tab_focused"}"#));
+    }
+}
+
+fn must_wait_for_lock(toggle: bool, event_json: &str) -> bool {
+    toggle || launch::event_kind(event_json) == "tab_created"
 }

--- a/plugins/herdr-sidebar/src/explorer_app.rs
+++ b/plugins/herdr-sidebar/src/explorer_app.rs
@@ -1255,13 +1255,19 @@ impl App {
     /// Render the centered Settings popup and remember its rect for clicks.
     fn draw_settings(&mut self, frame: &mut Frame) {
         let rows = self.settings_rows();
+        let area = frame.area();
+        let desired_width = rows
+            .iter()
+            .map(|(_, label, value, _)| label.chars().count() + value.chars().count() + 5)
+            .max()
+            .unwrap_or(30)
+            .max(30) as u16;
+        let width = desired_width.min(area.width);
         // The hotkey reference lives here now; the footer chips are opt-in.
-        let hint_lines = wrap_hints(&self.hints(), 28, 0);
+        let hint_lines = wrap_hints(&self.hints(), width.saturating_sub(2), 0);
         let Some(Overlay::Settings { selected, rect }) = self.overlay.as_mut() else {
             return;
         };
-        let area = frame.area();
-        let width = 30.min(area.width);
         let height = (rows.len() as u16 + 5 + hint_lines.len() as u16).min(area.height);
         let popup = Rect::new(
             (area.width.saturating_sub(width)) / 2,

--- a/plugins/herdr-sidebar/src/explorer_app.rs
+++ b/plugins/herdr-sidebar/src/explorer_app.rs
@@ -1299,7 +1299,7 @@ impl App {
             Style::default().bold(),
         )));
         lines.extend(hint_lines);
-        lines.push(Line::from(" click/⏎ toggle · ←/→ width · esc close".dim()));
+        lines.push(Line::from(" click/⏎ · ←/→ width · esc".dim()));
 
         frame.render_widget(Clear, popup);
         frame.render_widget(

--- a/plugins/herdr-sidebar/src/explorer_app.rs
+++ b/plugins/herdr-sidebar/src/explorer_app.rs
@@ -28,9 +28,6 @@ use herdr_sidebar::state::Exit;
 
 const MY_VIEW: View = View::Explorer;
 
-/// Expanded width to restore when nothing better is known.
-const DEFAULT_EXPANDED_WIDTH: u16 = 32;
-
 /// How often the git status decorations are re-read while the view is idle
 /// (issue #19's "live update"). Two cheap `git status` calls per repo; the
 /// explorer's own poll is 500ms, so this throttles them down to a quarter of
@@ -91,6 +88,41 @@ impl PaneCtl {
             }),
         );
     }
+
+    fn resize_preferred(&self, current: u16, target: u16, dock_right: bool) {
+        let Ok(layout) = herdr_sidebar::ipc::call_text(
+            "pane.layout",
+            serde_json::json!({ "pane_id": self.pane_id }),
+        ) else {
+            return;
+        };
+        let Some(step) = herdr_sidebar::launch::preferred_resize_plan(
+            &layout,
+            &self.pane_id,
+            current,
+            target,
+            dock_right,
+        ) else {
+            return;
+        };
+        let _ = herdr_sidebar::ipc::call_text(
+            "pane.resize",
+            serde_json::json!({
+                "pane_id": self.pane_id,
+                "direction": step.direction,
+                "amount": step.amount,
+            }),
+        );
+    }
+
+    fn layout_width(&self) -> Option<i64> {
+        let layout = herdr_sidebar::ipc::call_text(
+            "pane.layout",
+            serde_json::json!({ "pane_id": self.pane_id }),
+        )
+        .ok()?;
+        herdr_sidebar::launch::layout_width(&layout)
+    }
 }
 
 /// Where the tree body was drawn last frame, for mouse hit-testing.
@@ -147,6 +179,7 @@ enum Overlay {
 enum Setting {
     UnifiedSidebar,
     DockRight,
+    SidebarWidth,
     IconTheme,
     AutoOpen,
     FollowCwd,
@@ -176,6 +209,9 @@ pub struct App {
     /// Pane size from the last draw; sizing decisions and PageUp/PageDown
     /// strides are based on what was actually rendered.
     last_width: u16,
+    /// Whole tab area width from the last layout snapshot. A divider drag
+    /// changes only this pane; surrounding terminal chrome changes this too.
+    last_layout_width: Option<i64>,
     last_height: u16,
     page: usize,
     /// Row index under the mouse cursor, for the hover highlight.
@@ -271,6 +307,7 @@ impl App {
             sidebar::load_state().icons,
         );
         let pane_ctl = PaneCtl::from_env();
+        let last_layout_width = pane_ctl.as_ref().and_then(PaneCtl::layout_width);
         // The other view ships in this same binary — always available.
         let other_exe = std::env::current_exe().ok();
         let sidebar_state = sidebar::load_state();
@@ -287,7 +324,8 @@ impl App {
             snap: restored_selection.is_some(),
             theme,
             pane_ctl,
-            last_width: DEFAULT_EXPANDED_WIDTH,
+            last_width: sidebar_state.sidebar_width,
+            last_layout_width,
             last_height: 24,
             page: 20,
             hovered: None,
@@ -325,7 +363,7 @@ impl App {
     /// the sidebar (an agent editing files, a commit in another pane) show up
     /// on their own. Self-throttling, so the event loop may call it freely.
     pub fn tick(&mut self) {
-        self.sync_git_decorations_setting();
+        self.sync_shared_settings();
         self.collect_decorations();
         if self.last_deco.elapsed() < DECO_REFRESH {
             return;
@@ -336,8 +374,16 @@ impl App {
     /// A separated Source Control pane can change this shared setting while
     /// the Explorer keeps running. Re-read just this field so the tree reacts
     /// without adopting unrelated process-local mode changes.
-    fn sync_git_decorations_setting(&mut self) {
-        let enabled = sidebar::load_state().git_deco;
+    fn sync_shared_settings(&mut self) {
+        let shared = sidebar::load_state();
+        self.sidebar_state.dock_right = shared.dock_right;
+        if shared.sidebar_width != self.sidebar_state.sidebar_width {
+            self.sidebar_state.sidebar_width = shared.sidebar_width;
+            if let Some(ctl) = &self.pane_ctl {
+                ctl.resize_preferred(self.last_width, shared.sidebar_width, shared.dock_right);
+            }
+        }
+        let enabled = shared.git_deco;
         if enabled == self.sidebar_state.git_deco {
             return;
         }
@@ -345,6 +391,25 @@ impl App {
         self.rediscover_repos();
         if !enabled {
             self.deco = Decorations::empty();
+        }
+    }
+
+    pub fn on_resize(&mut self, width: u16) {
+        self.last_width = width;
+        if let Some(ctl) = &self.pane_ctl {
+            let layout_width = ctl.layout_width();
+            let surrounding_changed = self
+                .last_layout_width
+                .zip(layout_width)
+                .is_some_and(|(before, now)| before != now);
+            self.last_layout_width = layout_width.or(self.last_layout_width);
+            if surrounding_changed {
+                ctl.resize_preferred(
+                    width,
+                    self.sidebar_state.sidebar_width,
+                    self.sidebar_state.dock_right,
+                );
+            }
         }
     }
 
@@ -837,9 +902,11 @@ impl App {
             Activate,
             ConfirmPrompt,
             ToggleSetting(usize),
+            AdjustWidth(bool),
             DeleteConfirmed(PathBuf, bool),
         }
-        let row_count = self.settings_rows().len();
+        let settings = self.settings_rows();
+        let row_count = settings.len();
         let cmd = match self.overlay.as_mut() {
             Some(Overlay::Settings { selected, .. }) => match key.code {
                 KeyCode::Esc | KeyCode::Char('q') | KeyCode::Char('s') => Cmd::Close,
@@ -850,6 +917,18 @@ impl App {
                 KeyCode::Down | KeyCode::Char('j') => {
                     *selected = (*selected + 1).min(row_count.saturating_sub(1));
                     Cmd::Nothing
+                }
+                KeyCode::Left | KeyCode::Char('h')
+                    if settings.get(*selected).map(|row| row.0)
+                        == Some(Setting::SidebarWidth) =>
+                {
+                    Cmd::AdjustWidth(false)
+                }
+                KeyCode::Right | KeyCode::Char('l')
+                    if settings.get(*selected).map(|row| row.0)
+                        == Some(Setting::SidebarWidth) =>
+                {
+                    Cmd::AdjustWidth(true)
                 }
                 KeyCode::Enter | KeyCode::Char(' ') => Cmd::ToggleSetting(*selected),
                 _ => Cmd::Nothing,
@@ -896,6 +975,7 @@ impl App {
             Cmd::Activate => self.activate_menu_entry(),
             Cmd::ConfirmPrompt => self.confirm_prompt(),
             Cmd::ToggleSetting(index) => self.toggle_setting(index),
+            Cmd::AdjustWidth(wider) => self.adjust_sidebar_width(wider),
             Cmd::DeleteConfirmed(path, is_dir) => {
                 self.overlay = None;
                 match actions::delete(&path, is_dir) {
@@ -1035,6 +1115,12 @@ impl App {
                 true,
             ),
             (
+                Setting::SidebarWidth,
+                "Sidebar width",
+                format!("{} cols", self.sidebar_state.sidebar_width),
+                true,
+            ),
+            (
                 Setting::IconTheme,
                 "Icon theme",
                 match self.theme {
@@ -1121,6 +1207,7 @@ impl App {
                 self.sidebar_state =
                     sidebar::update_state(|state| state.dock_right = !state.dock_right);
             }
+            Setting::SidebarWidth => self.adjust_sidebar_width(true),
             Setting::IconTheme => self.set_theme(self.theme.toggled()),
             Setting::HiddenFiles => {
                 self.tree.show_hidden = !self.tree.show_hidden;
@@ -1149,6 +1236,19 @@ impl App {
                 self.overlay = None;
                 self.change_folder_dialog();
             }
+        }
+    }
+
+    fn adjust_sidebar_width(&mut self, wider: bool) {
+        self.sidebar_state = sidebar::update_state(|state| {
+            state.sidebar_width = sidebar::step_sidebar_width(state.sidebar_width, wider);
+        });
+        if let Some(ctl) = &self.pane_ctl {
+            ctl.resize_preferred(
+                self.last_width,
+                self.sidebar_state.sidebar_width,
+                self.sidebar_state.dock_right,
+            );
         }
     }
 
@@ -1193,7 +1293,7 @@ impl App {
             Style::default().bold(),
         )));
         lines.extend(hint_lines);
-        lines.push(Line::from(" click/⏎ toggle · esc close".dim()));
+        lines.push(Line::from(" click/⏎ toggle · ←/→ width · esc close".dim()));
 
         frame.render_widget(Clear, popup);
         frame.render_widget(

--- a/plugins/herdr-sidebar/src/launch.rs
+++ b/plugins/herdr-sidebar/src/launch.rs
@@ -21,8 +21,8 @@ pub const PANE_LABEL: &str = "Explorer";
 /// Explorer independently of the (cosmetic, clearable) label.
 pub const METADATA_SOURCE: &str = "herdr-sidebar-explorer";
 
-/// Preferred explorer width in columns; the ratio is derived from the target pane.
-const TARGET_COLS: f64 = 32.0;
+const MIN_SIDEBAR_SHARE: f64 = 0.15;
+const MAX_SIDEBAR_SHARE: f64 = 0.5;
 
 #[derive(Deserialize)]
 struct PaneListMsg {
@@ -414,7 +414,7 @@ fn sibling_cwds(pane_list_json: &str, my_pane_id: &str) -> Vec<SiblingCwd> {
 /// `<pane_id>\t<ratio>\t<swap>` for the configured edge. Left docking splits
 /// the leftmost pane and swaps; right docking splits the rightmost pane with
 /// an inverted original-pane ratio and needs no swap. Empty on any failure.
-pub fn open_plan(layout_json: &str, dock_right: bool) -> String {
+pub fn open_plan(layout_json: &str, dock_right: bool, target_cols: u16) -> String {
     let Ok(msg) = serde_json::from_str::<LayoutMsg>(strip_bom(layout_json)) else {
         return String::new();
     };
@@ -441,9 +441,17 @@ pub fn open_plan(layout_json: &str, dock_right: bool) -> String {
     let Some((id, rect)) = best else {
         return String::new();
     };
-    let sidebar_share = (TARGET_COLS / rect.width as f64).clamp(0.15, 0.5);
+    let sidebar_share =
+        (f64::from(target_cols) / rect.width as f64).clamp(MIN_SIDEBAR_SHARE, MAX_SIDEBAR_SHARE);
     let ratio = if dock_right { 1.0 - sidebar_share } else { sidebar_share };
-    format!("{id}\t{ratio:.2}\t{}", !dock_right)
+    format!("{id}\t{ratio:.6}\t{}", !dock_right)
+}
+
+/// Width of the whole tab area that owns a pane split. A pane-only divider
+/// resize leaves this unchanged; terminal chrome/sidebar changes do not.
+pub fn layout_width(layout_json: &str) -> Option<i64> {
+    let msg = serde_json::from_str::<LayoutMsg>(strip_bom(layout_json)).ok()?;
+    msg.result.layout.area.map(|area| area.width)
 }
 
 /// The tab (preferred) or workspace the event concerns, from
@@ -507,8 +515,9 @@ pub fn focused_pane_in(pane_list_json: &str, scope: &str) -> String {
 ///
 /// All five hooks run the SAME script, so the payload is the only way to
 /// treat space creation differently from an ordinary focus. The envelope
-/// shape is undocumented, so the discriminator is looked for at the top level
-/// and under the usual wrappers.
+/// `EventEnvelope` currently serializes the discriminator as lower_snake in
+/// `event`, while manifest hook names use dotted form. Both are accepted, and
+/// the usual nested wrappers remain supported for older payload shapes.
 ///
 /// The result is interpolated into a shell command, so it is restricted to a
 /// plain `lower_snake` identifier; anything else yields "".
@@ -524,10 +533,11 @@ pub fn event_kind(event_json: &str) -> String {
             None => None,
         })
         .unwrap_or_default();
+    let kind = kind.replace('.', "_");
     let safe = !kind.is_empty()
         && kind.chars().all(|c| c.is_ascii_lowercase() || c == '_')
         && kind.len() <= 64;
-    if safe { kind.to_string() } else { String::new() }
+    if safe { kind } else { String::new() }
 }
 
 /// A workspace's label from a `workspace list` JSON, empty when unknown.
@@ -720,6 +730,44 @@ pub fn resize_plan(
     term_cols_target: u16,
     dock_right: bool,
 ) -> Option<ResizeStep> {
+    resize_plan_inner(
+        layout_json,
+        pane_id,
+        term_cols_now,
+        term_cols_target,
+        dock_right,
+        false,
+    )
+}
+
+/// Re-assert a preferred column width after the tab's available width changes.
+/// The target is exact in the normal range, but yields to the same 15%-50%
+/// share bounds used when the sidebar first spawns.
+pub fn preferred_resize_plan(
+    layout_json: &str,
+    pane_id: &str,
+    term_cols_now: u16,
+    preferred_cols: u16,
+    dock_right: bool,
+) -> Option<ResizeStep> {
+    resize_plan_inner(
+        layout_json,
+        pane_id,
+        term_cols_now,
+        preferred_cols,
+        dock_right,
+        true,
+    )
+}
+
+fn resize_plan_inner(
+    layout_json: &str,
+    pane_id: &str,
+    term_cols_now: u16,
+    term_cols_target: u16,
+    dock_right: bool,
+    clamp_share: bool,
+) -> Option<ResizeStep> {
     let msg = serde_json::from_str::<LayoutMsg>(strip_bom(layout_json)).ok()?;
     let layout = &msg.result.layout;
     let pane_rect = layout
@@ -728,11 +776,6 @@ pub fn resize_plan(
         .find(|p| p.pane_id.as_deref() == Some(pane_id))?
         .rect
         .as_ref()?;
-    // The pane rect can be a couple of columns wider than the terminal inside
-    // it (pane chrome); express the target in rect space.
-    let chrome = pane_rect.width - i64::from(term_cols_now);
-    let target_rect_w = i64::from(term_cols_target) + chrome.max(0);
-
     let divider_x = if dock_right { pane_rect.x } else { pane_rect.x + pane_rect.width };
     let split = layout
         .splits
@@ -744,6 +787,19 @@ pub fn resize_plan(
             rect.x <= pane_rect.x && (split_divider - divider_x).abs() <= 2 && rect.width > 0
         })
         .min_by_key(|(rect, _)| rect.width)?;
+
+    // The pane rect can be a couple of columns wider than the terminal inside
+    // it (pane chrome); express the target in rect space. Preferred-width
+    // reassertion keeps the content usable at extreme tab widths.
+    let chrome = pane_rect.width - i64::from(term_cols_now);
+    let requested = i64::from(term_cols_target) + chrome.max(0);
+    let target_rect_w = if clamp_share {
+        let min = (split.0.width as f64 * MIN_SIDEBAR_SHARE).ceil() as i64;
+        let max = (split.0.width as f64 * MAX_SIDEBAR_SHARE).floor() as i64;
+        requested.clamp(min, max.max(min))
+    } else {
+        requested
+    };
 
     let delta = (target_rect_w - pane_rect.width) as f64 / split.0.width as f64;
     if delta.abs() < 0.005 {
@@ -860,6 +916,7 @@ mod tests {
             event_kind(r#"{"event":{"type":"tab_focused"}}"#),
             "tab_focused"
         );
+        assert_eq!(event_kind(r#"{"event":"tab.created"}"#), "tab_created");
     }
 
     /// The kind is interpolated into a shell command, so anything that is not
@@ -1083,7 +1140,7 @@ mod tests {
             "\u{feff}{}",
             layout(r#"{"pane_id":"w1:p1","rect":{"x":0,"y":0,"width":90,"height":50}}"#)
         );
-        assert_eq!(open_plan(&layout_json, false), "w1:p1\t0.36\ttrue");
+        assert_eq!(open_plan(&layout_json, false, 32), "w1:p1\t0.355556\ttrue");
     }
 
     #[test]
@@ -1107,10 +1164,10 @@ mod tests {
                {"pane_id":"w1:p3","rect":{"x":29,"y":36,"width":90,"height":35}},
                {"pane_id":"w1:p1","rect":{"x":29,"y":1,"width":90,"height":35}}"#,
         );
-        let plan = open_plan(&json, false);
+        let plan = open_plan(&json, false, 32);
         let (id, ratio) = plan.split_once('\t').unwrap();
         assert_eq!(id, "w1:p1");
-        assert_eq!(ratio, "0.36\ttrue"); // 32 / 90, then swap left
+        assert_eq!(ratio, "0.355556\ttrue"); // 32 / 90, then swap left
     }
 
     #[test]
@@ -1120,17 +1177,25 @@ mod tests {
                {"pane_id":"w1:p3","rect":{"x":29,"y":1,"width":90,"height":70}},
                {"pane_id":"w1:p1","rect":{"x":119,"y":1,"width":90,"height":35}}"#,
         );
-        assert_eq!(open_plan(&json, true), "w1:p1\t0.64\tfalse");
+        assert_eq!(open_plan(&json, true, 32), "w1:p1\t0.644444\tfalse");
     }
 
     #[test]
     fn open_plan_clamps_ratio() {
         let wide = layout(r#"{"pane_id":"w1:p1","rect":{"x":0,"y":0,"width":400,"height":50}}"#);
-        assert_eq!(open_plan(&wide, false), "w1:p1\t0.15\ttrue");
-        assert_eq!(open_plan(&wide, true), "w1:p1\t0.85\tfalse");
+        assert_eq!(open_plan(&wide, false, 32), "w1:p1\t0.150000\ttrue");
+        assert_eq!(open_plan(&wide, true, 32), "w1:p1\t0.850000\tfalse");
         let narrow = layout(r#"{"pane_id":"w1:p1","rect":{"x":0,"y":0,"width":40,"height":50}}"#);
-        assert_eq!(open_plan(&narrow, false), "w1:p1\t0.50\ttrue");
-        assert_eq!(open_plan(&narrow, true), "w1:p1\t0.50\tfalse");
+        assert_eq!(open_plan(&narrow, false, 32), "w1:p1\t0.500000\ttrue");
+        assert_eq!(open_plan(&narrow, true, 32), "w1:p1\t0.500000\tfalse");
+        assert_eq!(open_plan(&narrow, false, 24), "w1:p1\t0.500000\ttrue");
+    }
+
+    #[test]
+    fn layout_width_distinguishes_tab_area_from_pane_width() {
+        let json = r#"{"result":{"layout":{"area":{"x":0,"y":0,"width":174,"height":50},"panes":[{"pane_id":"e","rect":{"x":0,"y":0,"width":42,"height":50}}]}}}"#;
+        assert_eq!(layout_width(json), Some(174));
+        assert_eq!(layout_width("not json"), None);
     }
 
     #[test]
@@ -1239,6 +1304,25 @@ mod tests {
     }
 
     #[test]
+    fn preferred_resize_plan_pins_columns_but_yields_at_extremes() {
+        let normal = layout_with_splits(
+            r#"{"pane_id":"e","rect":{"x":0,"y":0,"width":39,"height":50}}"#,
+            r#"{"direction":"right","ratio":0.195,"rect":{"x":0,"y":0,"width":200,"height":50}}"#,
+        );
+        let step = preferred_resize_plan(&normal, "e", 37, 42, false).unwrap();
+        assert_eq!(step.direction, "right");
+        assert!((step.amount - 5.0 / 200.0).abs() < 1e-9);
+
+        let narrow = layout_with_splits(
+            r#"{"pane_id":"e","rect":{"x":0,"y":0,"width":20,"height":50}}"#,
+            r#"{"direction":"right","ratio":0.333333,"rect":{"x":0,"y":0,"width":60,"height":50}}"#,
+        );
+        let step = preferred_resize_plan(&narrow, "e", 18, 42, false).unwrap();
+        assert_eq!(step.direction, "right");
+        assert!((step.amount - 10.0 / 60.0).abs() < 1e-9);
+    }
+
+    #[test]
     fn resize_plan_picks_innermost_matching_split() {
         // Nested: root split (divider elsewhere) plus the inner split whose
         // divider is at the explorer's right edge.
@@ -1268,9 +1352,9 @@ mod tests {
 
     #[test]
     fn open_plan_is_empty_on_failure() {
-        assert_eq!(open_plan("not json", false), "");
-        assert_eq!(open_plan(&layout(""), false), "");
+        assert_eq!(open_plan("not json", false, 32), "");
+        assert_eq!(open_plan(&layout(""), false, 32), "");
         let unsafe_id = layout(r#"{"pane_id":"--x","rect":{"x":0,"y":0,"width":90,"height":50}}"#);
-        assert_eq!(open_plan(&unsafe_id, true), "");
+        assert_eq!(open_plan(&unsafe_id, true, 32), "");
     }
 }

--- a/plugins/herdr-sidebar/src/main.rs
+++ b/plugins/herdr-sidebar/src/main.rs
@@ -61,8 +61,8 @@ fn main() -> std::io::Result<()> {
             return Ok(());
         }
         Some("--open-plan") => {
-            let dock_right = state::load_state().dock_right;
-            println!("{}", launch::open_plan(&read_stdin()?, dock_right));
+            let state = state::load_state();
+            println!("{}", launch::open_plan(&read_stdin()?, state.dock_right, state.sidebar_width));
             return Ok(());
         }
         Some("--event-kind") => {
@@ -222,6 +222,10 @@ fn run_explorer(
             let exit = match event::read()? {
                 Event::Key(key) => app.on_key(key),
                 Event::Mouse(mouse) => app.on_mouse(mouse),
+                Event::Resize(width, _) => {
+                    app.on_resize(width);
+                    None
+                }
                 _ => None, // resize, focus, … simply fall through to a redraw
             };
             if let Some(exit) = exit {
@@ -257,6 +261,10 @@ fn run_scm(
             let exit = match event::read()? {
                 Event::Key(key) => app.on_key(key),
                 Event::Mouse(mouse) => app.on_mouse(mouse),
+                Event::Resize(width, _) => {
+                    app.on_resize(width);
+                    None
+                }
                 _ => None,
             };
             if let Some(exit) = exit {

--- a/plugins/herdr-sidebar/src/scm_app.rs
+++ b/plugins/herdr-sidebar/src/scm_app.rs
@@ -410,6 +410,7 @@ enum Overlay {
 enum Setting {
     UnifiedSidebar,
     DockRight,
+    SidebarWidth,
     IconTheme,
     AutoOpen,
     FollowCwd,
@@ -493,6 +494,41 @@ impl PaneCtl {
         );
     }
 
+    fn resize_preferred(&self, current: u16, target: u16, dock_right: bool) {
+        let Ok(layout) = herdr_sidebar::ipc::call_text(
+            "pane.layout",
+            serde_json::json!({ "pane_id": self.pane_id }),
+        ) else {
+            return;
+        };
+        let Some(step) = herdr_sidebar::launch::preferred_resize_plan(
+            &layout,
+            &self.pane_id,
+            current,
+            target,
+            dock_right,
+        ) else {
+            return;
+        };
+        let _ = herdr_sidebar::ipc::call_text(
+            "pane.resize",
+            serde_json::json!({
+                "pane_id": self.pane_id,
+                "direction": step.direction,
+                "amount": step.amount,
+            }),
+        );
+    }
+
+    fn layout_width(&self) -> Option<i64> {
+        let layout = herdr_sidebar::ipc::call_text(
+            "pane.layout",
+            serde_json::json!({ "pane_id": self.pane_id }),
+        )
+        .ok()?;
+        herdr_sidebar::launch::layout_width(&layout)
+    }
+
     /// Report identity tokens: always our own; in merged mode also the other
     /// view's (one Sidebar pane satisfies both plugins' launchers), otherwise
     /// clear the other view's token.
@@ -550,6 +586,9 @@ pub struct App {
     last_preview: Option<(String, herdr_sidebar::viewer::PreviewTarget)>,
     page: usize,
     last_width: u16,
+    /// Whole tab area width from the last layout snapshot. Divider-only
+    /// resizes leave this unchanged and are therefore respected.
+    last_layout_width: Option<i64>,
     last_height: u16,
     // Merged-sidebar state.
     sidebar_state: sidebar::State,
@@ -592,6 +631,7 @@ impl App {
         let other_exe = std::env::current_exe().ok();
         let sidebar_state = sidebar::load_state();
         let pane_ctl = PaneCtl::from_env();
+        let last_layout_width = pane_ctl.as_ref().and_then(PaneCtl::layout_width);
 
         // Mirror the SCM view the user was already looking at: a sidebar docked
         // into a brand-new preview tab starts with the same drawers expanded,
@@ -642,7 +682,8 @@ impl App {
             last_click: None,
             last_preview: None,
             page: 20,
-            last_width: 40,
+            last_width: sidebar_state.sidebar_width,
+            last_layout_width,
             last_height: 24,
             sidebar_state,
             other_exe,
@@ -784,7 +825,15 @@ impl App {
     /// Periodic timer tick: retry repo discovery if we started outside one,
     /// pick up external changes, and collect finished ✧ suggestion / sync runs.
     pub fn tick(&mut self) {
-        self.sidebar_state.git_deco = sidebar::load_state().git_deco;
+        let shared = sidebar::load_state();
+        self.sidebar_state.git_deco = shared.git_deco;
+        self.sidebar_state.dock_right = shared.dock_right;
+        if shared.sidebar_width != self.sidebar_state.sidebar_width {
+            self.sidebar_state.sidebar_width = shared.sidebar_width;
+            if let Some(ctl) = &self.pane_ctl {
+                ctl.resize_preferred(self.last_width, shared.sidebar_width, shared.dock_right);
+            }
+        }
         if let Some(rx) = &self.suggesting {
             match rx.try_recv() {
                 Ok(message) => {
@@ -833,6 +882,25 @@ impl App {
             }
         }
         self.refresh();
+    }
+
+    pub fn on_resize(&mut self, width: u16) {
+        self.last_width = width;
+        if let Some(ctl) = &self.pane_ctl {
+            let layout_width = ctl.layout_width();
+            let surrounding_changed = self
+                .last_layout_width
+                .zip(layout_width)
+                .is_some_and(|(before, now)| before != now);
+            self.last_layout_width = layout_width.or(self.last_layout_width);
+            if surrounding_changed {
+                ctl.resize_preferred(
+                    width,
+                    self.sidebar_state.sidebar_width,
+                    self.sidebar_state.dock_right,
+                );
+            }
+        }
     }
 
     /// The title bar's Collapse All: fold every repo section and drawer. The
@@ -1447,10 +1515,12 @@ impl App {
             Close,
             Activate,
             ToggleSetting(usize),
+            AdjustWidth(bool),
             DiscardConfirmed(usize, FileEntry),
             GitConfirmed(usize, Vec<String>),
         }
-        let row_count = self.settings_rows().len();
+        let settings = self.settings_rows();
+        let row_count = settings.len();
         let cmd = match self.overlay.as_mut() {
             Some(Overlay::Menu {
                 entries, selected, ..
@@ -1477,6 +1547,18 @@ impl App {
                     *selected = (*selected + 1).min(row_count.saturating_sub(1));
                     Cmd::Nothing
                 }
+                KeyCode::Left | KeyCode::Char('h')
+                    if settings.get(*selected).map(|row| row.0)
+                        == Some(Setting::SidebarWidth) =>
+                {
+                    Cmd::AdjustWidth(false)
+                }
+                KeyCode::Right | KeyCode::Char('l')
+                    if settings.get(*selected).map(|row| row.0)
+                        == Some(Setting::SidebarWidth) =>
+                {
+                    Cmd::AdjustWidth(true)
+                }
                 KeyCode::Enter | KeyCode::Char(' ') => Cmd::ToggleSetting(*selected),
                 _ => Cmd::Nothing,
             },
@@ -1497,6 +1579,7 @@ impl App {
             Cmd::Close => self.overlay = None,
             Cmd::Activate => self.activate_menu_entry(),
             Cmd::ToggleSetting(index) => self.toggle_setting(index),
+            Cmd::AdjustWidth(wider) => self.adjust_sidebar_width(wider),
             Cmd::GitConfirmed(repo, args) => {
                 self.overlay = None;
                 let strs: Vec<&str> = args.iter().map(String::as_str).collect();
@@ -1640,6 +1723,12 @@ impl App {
                 true,
             ),
             (
+                Setting::SidebarWidth,
+                "Sidebar width",
+                format!("{} cols", self.sidebar_state.sidebar_width),
+                true,
+            ),
+            (
                 Setting::IconTheme,
                 "Icon theme",
                 match self.theme {
@@ -1718,6 +1807,7 @@ impl App {
                 self.sidebar_state =
                     sidebar::update_state(|state| state.dock_right = !state.dock_right);
             }
+            Setting::SidebarWidth => self.adjust_sidebar_width(true),
             Setting::IconTheme => self.set_theme(self.theme.toggled()),
             Setting::Hotkeys => {
                 self.sidebar_state =
@@ -1740,6 +1830,19 @@ impl App {
                 self.overlay = None;
                 self.change_folder_dialog();
             }
+        }
+    }
+
+    fn adjust_sidebar_width(&mut self, wider: bool) {
+        self.sidebar_state = sidebar::update_state(|state| {
+            state.sidebar_width = sidebar::step_sidebar_width(state.sidebar_width, wider);
+        });
+        if let Some(ctl) = &self.pane_ctl {
+            ctl.resize_preferred(
+                self.last_width,
+                self.sidebar_state.sidebar_width,
+                self.sidebar_state.dock_right,
+            );
         }
     }
 
@@ -1837,7 +1940,7 @@ impl App {
             Style::default().bold(),
         )));
         lines.extend(hint_lines);
-        lines.push(Line::from(" click/⏎ toggle · esc close".dim()));
+        lines.push(Line::from(" click/⏎ toggle · ←/→ width · esc close".dim()));
 
         frame.render_widget(Clear, popup);
         frame.render_widget(

--- a/plugins/herdr-sidebar/src/scm_app.rs
+++ b/plugins/herdr-sidebar/src/scm_app.rs
@@ -1946,7 +1946,7 @@ impl App {
             Style::default().bold(),
         )));
         lines.extend(hint_lines);
-        lines.push(Line::from(" click/⏎ toggle · ←/→ width · esc close".dim()));
+        lines.push(Line::from(" click/⏎ · ←/→ width · esc".dim()));
 
         frame.render_widget(Clear, popup);
         frame.render_widget(

--- a/plugins/herdr-sidebar/src/scm_app.rs
+++ b/plugins/herdr-sidebar/src/scm_app.rs
@@ -1902,13 +1902,19 @@ impl App {
     /// Render the centered Settings popup and remember its rect for clicks.
     fn draw_settings(&mut self, frame: &mut Frame) {
         let rows = self.settings_rows();
+        let area = frame.area();
+        let desired_width = rows
+            .iter()
+            .map(|(_, label, value, _)| label.chars().count() + value.chars().count() + 5)
+            .max()
+            .unwrap_or(30)
+            .max(30) as u16;
+        let width = desired_width.min(area.width);
         // The hotkey reference lives here now; the footer chips are opt-in.
-        let hint_lines = wrap_hints(&self.hints(), 28, 0);
+        let hint_lines = wrap_hints(&self.hints(), width.saturating_sub(2), 0);
         let Some(Overlay::Settings { selected, rect }) = self.overlay.as_mut() else {
             return;
         };
-        let area = frame.area();
-        let width = 30.min(area.width);
         let height = (rows.len() as u16 + 5 + hint_lines.len() as u16).min(area.height);
         let popup = Rect::new(
             (area.width.saturating_sub(width)) / 2,

--- a/plugins/herdr-sidebar/src/state.rs
+++ b/plugins/herdr-sidebar/src/state.rs
@@ -8,6 +8,7 @@
 //!   left off.
 //! - `follow_cwd`: follow the live cwd of the neighbouring pane.
 //! - `dock_right`: dock at the right edge instead of the default left edge.
+//! - `sidebar_width`: preferred sidebar width in terminal columns.
 //!
 //! Both views live in ONE binary; switching is an in-process re-render, and
 //! separated panes are the same binary pinned to a starting view with
@@ -17,6 +18,24 @@ use std::path::{Path, PathBuf};
 
 /// Pane label (and metadata identity) of the unified pane.
 pub const SIDEBAR_LABEL: &str = "Sidebar";
+
+pub const DEFAULT_SIDEBAR_WIDTH: u16 = 32;
+pub const MIN_SIDEBAR_WIDTH: u16 = 24;
+pub const MAX_SIDEBAR_WIDTH: u16 = 80;
+pub const SIDEBAR_WIDTH_STEP: u16 = 4;
+
+pub fn clamp_sidebar_width(width: u16) -> u16 {
+    width.clamp(MIN_SIDEBAR_WIDTH, MAX_SIDEBAR_WIDTH)
+}
+
+pub fn step_sidebar_width(width: u16, wider: bool) -> u16 {
+    let width = clamp_sidebar_width(width);
+    if wider {
+        (width + SIDEBAR_WIDTH_STEP).min(MAX_SIDEBAR_WIDTH)
+    } else {
+        width.saturating_sub(SIDEBAR_WIDTH_STEP).max(MIN_SIDEBAR_WIDTH)
+    }
+}
 
 /// Shell-agnostic command name typed into panes we create. [`spawn_env`]
 /// prepends this binary's directory to PATH, so PowerShell, cmd, sh, bash,
@@ -144,6 +163,10 @@ pub struct State {
     /// Dock the sidebar at the right edge of each tab. False preserves the
     /// historical left dock.
     pub dock_right: bool,
+    /// Preferred pane width in terminal columns. Layout code keeps this
+    /// column target in the normal range and yields proportionally when the
+    /// tab becomes unusually narrow.
+    pub sidebar_width: u16,
 }
 
 impl Default for State {
@@ -158,6 +181,7 @@ impl Default for State {
             follow_cwd: true,
             git_deco: true,
             dock_right: false,
+            sidebar_width: DEFAULT_SIDEBAR_WIDTH,
         }
     }
 }
@@ -294,7 +318,7 @@ fn write_state(path: &Path, state: State) {
         None => String::new(),
     };
     let json = format!(
-        "{{\"merged\":{},\"active\":\"{}\",\"hotkeys\":{},\"font_prompt\":{},\"auto_open\":{},\"follow_cwd\":{},\"git_deco\":{},\"dock_right\":{}{icons}}}",
+        "{{\"merged\":{},\"active\":\"{}\",\"hotkeys\":{},\"font_prompt\":{},\"auto_open\":{},\"follow_cwd\":{},\"git_deco\":{},\"dock_right\":{},\"sidebar_width\":{}{icons}}}",
         state.merged,
         state.active.state_name(),
         state.show_hotkeys,
@@ -302,7 +326,8 @@ fn write_state(path: &Path, state: State) {
         state.auto_open,
         state.follow_cwd,
         state.git_deco,
-        state.dock_right
+        state.dock_right,
+        clamp_sidebar_width(state.sidebar_width)
     );
     let _ = std::fs::write(path, json);
 }
@@ -677,6 +702,12 @@ pub fn parse_state(json: &str) -> State {
             .get("dock_right")
             .and_then(|v| v.as_bool())
             .unwrap_or(default.dock_right),
+        sidebar_width: value
+            .get("sidebar_width")
+            .and_then(|v| v.as_u64())
+            .and_then(|v| u16::try_from(v).ok())
+            .map(clamp_sidebar_width)
+            .unwrap_or(default.sidebar_width),
     }
 }
 
@@ -790,8 +821,9 @@ mod tests {
             follow_cwd: false,
             git_deco: false,
             dock_right: true,
+            sidebar_width: 44,
         };
-        let json = "{\"merged\":true,\"active\":\"source-control\",\"hotkeys\":true,\"font_prompt\":true,\"auto_open\":false,\"follow_cwd\":false,\"git_deco\":false,\"dock_right\":true,\"icons\":\"emoji\"}";
+        let json = "{\"merged\":true,\"active\":\"source-control\",\"hotkeys\":true,\"font_prompt\":true,\"auto_open\":false,\"follow_cwd\":false,\"git_deco\":false,\"dock_right\":true,\"sidebar_width\":44,\"icons\":\"emoji\"}";
         assert_eq!(parse_state(json), state);
         assert!(parse_state("\u{feff}{\"merged\":true}").merged);
         // Files written before the flag existed keep auto-open AND the git
@@ -802,8 +834,21 @@ mod tests {
         assert!(parse_state("{\"merged\":true}").git_deco);
         // Files written before the dock setting existed stay left-docked.
         assert!(!parse_state("{\"merged\":true}").dock_right);
+        assert_eq!(parse_state("{\"merged\":true}").sidebar_width, 32);
+        assert_eq!(parse_state("{\"sidebar_width\":1}").sidebar_width, 24);
+        assert_eq!(parse_state("{\"sidebar_width\":999}").sidebar_width, 80);
         assert_eq!(parse_state("garbage"), State::default());
         assert_eq!(parse_state("{\"active\":\"bogus\"}"), State::default());
+    }
+
+    #[test]
+    fn sidebar_width_steps_and_saturates_within_supported_bounds() {
+        assert_eq!(step_sidebar_width(32, true), 36);
+        assert_eq!(step_sidebar_width(32, false), 28);
+        assert_eq!(step_sidebar_width(MAX_SIDEBAR_WIDTH, true), MAX_SIDEBAR_WIDTH);
+        assert_eq!(step_sidebar_width(MIN_SIDEBAR_WIDTH, false), MIN_SIDEBAR_WIDTH);
+        assert_eq!(step_sidebar_width(1, true), 28);
+        assert_eq!(step_sidebar_width(u16::MAX, false), 76);
     }
 
     #[test]

--- a/plugins/herdr-sidebar/src/state.rs
+++ b/plugins/herdr-sidebar/src/state.rs
@@ -189,7 +189,7 @@ impl Default for State {
 pub fn follow_cwd_setting_value(enabled: bool) -> String {
     let value = if enabled { "on" } else { "off" };
     if cfg!(windows) {
-        format!("{value} (host unsupported)")
+        format!("{value} (host n/a)")
     } else {
         value.to_string()
     }
@@ -849,6 +849,17 @@ mod tests {
         assert_eq!(step_sidebar_width(MIN_SIDEBAR_WIDTH, false), MIN_SIDEBAR_WIDTH);
         assert_eq!(step_sidebar_width(1, true), 28);
         assert_eq!(step_sidebar_width(u16::MAX, false), 76);
+    }
+
+    #[test]
+    fn follow_cwd_status_stays_compact() {
+        if cfg!(windows) {
+            assert_eq!(follow_cwd_setting_value(true), "on (host n/a)");
+            assert_eq!(follow_cwd_setting_value(false), "off (host n/a)");
+        } else {
+            assert_eq!(follow_cwd_setting_value(true), "on");
+            assert_eq!(follow_cwd_setting_value(false), "off");
+        }
     }
 
     #[test]

--- a/plugins/herdr-sidebar/src/viewer.rs
+++ b/plugins/herdr-sidebar/src/viewer.rs
@@ -947,10 +947,25 @@ fn close_own_pane(control: &Path) {
                 .as_deref()
                 .is_some_and(|json| tab_is_plugin_only(json, &preview.tab_id))
     }) {
-        let _ = ipc::call_text("tab.close", serde_json::json!({ "tab_id": preview.tab_id }));
+        close_preview_tab(&preview);
     } else {
         let _ = ipc::call_text("pane.close", serde_json::json!({ "pane_id": pane_id }));
     }
+}
+
+fn close_preview_tab(preview: &PreviewPane) {
+    // Focus first: closing our own tab kills this process, so code after a
+    // successful tab.close is not guaranteed to run.
+    if !preview.origin_tab_id.is_empty() {
+        let _ = ipc::call_text(
+            "tab.focus",
+            serde_json::json!({ "tab_id": preview.origin_tab_id }),
+        );
+    }
+    let _ = ipc::call_text(
+        "tab.close",
+        serde_json::json!({ "tab_id": preview.tab_id }),
+    );
 }
 
 fn pin_own_tab(doc_key: &str) {
@@ -1573,6 +1588,7 @@ pub fn open_in_pane(
 ) -> Result<PreviewTarget, String> {
     let list = ipc::call_text("pane.list", serde_json::json!({}))
         .map_err(|e| format!("preview failed: {e}"))?;
+    let caller_tab_id = crate::launch::tab_of(&list, my_pane_id);
     sweep_orphan_controls(&list);
     // Route only within OUR space. A session-wide search reused another
     // project's ephemeral tab and focus jumped there, which reads as the
@@ -1595,28 +1611,33 @@ pub fn open_in_pane(
     }
     previews.retain(|preview| !preview.stale);
     previews.sort_by(|a, b| a.tab_id.cmp(&b.tab_id).then(a.pane_id.cmp(&b.pane_id)));
+    let origin_tab_id = preview_origin_tab(&previews, &caller_tab_id);
 
     // 1. Already open — jump to it, pinned or not.
     if let Some(p) = preview_for_doc(&previews, doc_key) {
+        remember_origin(&p.pane_id, &origin_tab_id);
         let _ = ipc::call_text("tab.focus", serde_json::json!({ "tab_id": p.tab_id }));
         return Ok(PreviewTarget {
             pane_id: p.pane_id,
             tab_id: p.tab_id,
+            origin_tab_id,
         });
     }
 
     // 2. Overwrite the ephemeral tab.
     if let Some(p) = reusable_preview(&previews) {
         write_scratch_file(&p.control, payload).map_err(|e| format!("preview failed: {e}"))?;
+        remember_origin(&p.pane_id, &origin_tab_id);
         let _ = ipc::call_text("tab.focus", serde_json::json!({ "tab_id": p.tab_id }));
         return Ok(PreviewTarget {
             pane_id: p.pane_id,
             tab_id: p.tab_id,
+            origin_tab_id,
         });
     }
 
     // 3. Nothing reusable — a tab of its own.
-    spawn_preview_tab(my_pane_id, spawn_cwd, doc_key, payload)
+    spawn_preview_tab(my_pane_id, spawn_cwd, doc_key, payload, &origin_tab_id)
 }
 
 /// Where a preview request landed. Handed back so a double click can pin
@@ -1626,6 +1647,7 @@ pub fn open_in_pane(
 pub struct PreviewTarget {
     pub pane_id: String,
     pub tab_id: String,
+    pub origin_tab_id: String,
 }
 
 /// Mark a preview's tab pinned: wait briefly for a clean viewer to acknowledge
@@ -1677,6 +1699,7 @@ fn spawn_preview_tab(
     spawn_cwd: &Path,
     doc_key: &str,
     payload: &str,
+    origin_tab_id: &str,
 ) -> Result<PreviewTarget, String> {
     let (new_pane, control) = spawn_viewer_pane(my_pane_id, spawn_cwd, doc_key, payload)?;
     let moved = match ipc::call_text(
@@ -1708,6 +1731,7 @@ fn spawn_preview_tab(
         cleanup_moved_spawn(&new_pane, &tab_id, &control);
         return Err("preview tab could not record ownership".into());
     }
+    remember_origin(&new_pane, origin_tab_id);
     if !start_viewer_pane(&new_pane) {
         cleanup_moved_spawn(&new_pane, &tab_id, &control);
         return Err("preview process failed to start".into());
@@ -1715,7 +1739,22 @@ fn spawn_preview_tab(
     Ok(PreviewTarget {
         pane_id: new_pane,
         tab_id,
+        origin_tab_id: origin_tab_id.to_string(),
     })
+}
+
+fn remember_origin(pane_id: &str, tab_id: &str) {
+    if tab_id.is_empty() {
+        return;
+    }
+    let _ = ipc::call_text(
+        "pane.report_metadata",
+        serde_json::json!({
+            "pane_id": pane_id,
+            "source": METADATA_SOURCE,
+            "tokens": { TOKEN_ORIGIN_TAB: tab_id },
+        }),
+    );
 }
 
 /// Ask this tab's viewer to close (Esc from the sidebar). A live viewer owns
@@ -1733,8 +1772,7 @@ pub fn close_in_tab(my_pane_id: &str) {
                 && (preview.dedicated || preview.resumed)
                 && tab_is_plugin_only(&json, &preview.tab_id)
             {
-                let _ =
-                    ipc::call_text("tab.close", serde_json::json!({ "tab_id": preview.tab_id }));
+                close_preview_tab(&preview);
             } else {
                 let _ = ipc::call_text("pane.close", serde_json::json!({ "pane_id": id }));
             }
@@ -1805,6 +1843,7 @@ pub const TOKEN_PATH: &str = "hs-preview-path";
 pub const TOKEN_PINNED: &str = "hs-preview-pinned";
 pub const TOKEN_CONTROL: &str = "hs-preview-control";
 pub const TOKEN_DEDICATED: &str = "hs-preview-dedicated";
+pub const TOKEN_ORIGIN_TAB: &str = "hs-preview-origin-tab";
 
 /// A live preview pane and the document it is showing. State lives on the
 /// pane, so it cannot outlive what it describes.
@@ -1821,6 +1860,7 @@ pub struct PreviewPane {
     pub control: PathBuf,
     pub stale: bool,
     pub dedicated: bool,
+    pub origin_tab_id: String,
     /// Herdr restored the pane label but not its process metadata. This is a
     /// dead shell left behind by server resume, not a live unsaved editor.
     pub resumed: bool,
@@ -1898,6 +1938,12 @@ fn previews_in(pane_list_json: &str) -> Vec<PreviewPane> {
                 control,
                 stale,
                 dedicated: p.tokens.contains_key(TOKEN_DEDICATED),
+                origin_tab_id: p
+                    .tokens
+                    .get(TOKEN_ORIGIN_TAB)
+                    .and_then(|value| value.as_str())
+                    .unwrap_or_default()
+                    .to_string(),
                 resumed,
             })
         })
@@ -1966,6 +2012,22 @@ fn preview_for_doc(previews: &[PreviewPane], doc_key: &str) -> Option<PreviewPan
 /// The ephemeral tab, if one exists. Pinned tabs are never overwritten.
 fn reusable_preview(previews: &[PreviewPane]) -> Option<PreviewPane> {
     previews.iter().find(|p| !p.stale && !p.pinned).cloned()
+}
+
+/// An ephemeral preview's sidebar is itself a valid launch surface. Preserve
+/// the tab that originally opened it rather than recording the preview tab as
+/// its own return destination. A pinned preview is a normal caller tab.
+fn preview_origin_tab(previews: &[PreviewPane], caller_tab_id: &str) -> String {
+    previews
+        .iter()
+        .find(|preview| {
+            !preview.stale
+                && !preview.pinned
+                && preview.tab_id == caller_tab_id
+                && !preview.origin_tab_id.is_empty()
+        })
+        .map(|preview| preview.origin_tab_id.clone())
+        .unwrap_or_else(|| caller_tab_id.to_string())
 }
 
 /// Split a viewer pane directly to the caller's right: split the right
@@ -2422,7 +2484,7 @@ mod tests {
     const PREVIEWS: &str = r#"{"result":{"panes":[
         {"pane_id":"w4:p1","tab_id":"w4:t1","tokens":{"herdr-sidebar-explorer":"1"}},
         {"pane_id":"w4:p2","tab_id":"w4:t2",
-          "tokens":{"herdr-sidebar-preview":"9999999999","hs-preview-path":"/r/a.rs","hs-preview-pinned":"1","hs-preview-dedicated":"1","hs-preview-control":"C:/state/a preview.ctl"}},
+          "tokens":{"herdr-sidebar-preview":"9999999999","hs-preview-path":"/r/a.rs","hs-preview-pinned":"1","hs-preview-dedicated":"1","hs-preview-origin-tab":"w4:t1","hs-preview-control":"C:/state/a preview.ctl"}},
         {"pane_id":"w4:p3","tab_id":"w4:t3",
           "tokens":{"herdr-sidebar-preview":"9999999999","hs-preview-path":"/r/b.rs"}}
     ]}}"#;
@@ -2559,6 +2621,7 @@ mod tests {
         assert!(a.dedicated);
         assert!(!a.resumed);
         assert_eq!(a.tab_id, "w4:t2");
+        assert_eq!(a.origin_tab_id, "w4:t1");
         assert_eq!(a.control, PathBuf::from("C:/state/a preview.ctl"));
         assert!(
             !ps.iter()
@@ -2594,11 +2657,25 @@ mod tests {
     }
 
     #[test]
+    fn ephemeral_previews_preserve_the_original_return_tab() {
+        let mut previews = previews_in(PREVIEWS);
+        let ephemeral = previews
+            .iter_mut()
+            .find(|preview| !preview.pinned)
+            .unwrap();
+        ephemeral.origin_tab_id = "w4:t1".into();
+        assert_eq!(preview_origin_tab(&previews, "w4:t3"), "w4:t1");
+        assert_eq!(preview_origin_tab(&previews, "w4:t2"), "w4:t2");
+        assert_eq!(preview_origin_tab(&previews, "w4:t9"), "w4:t9");
+    }
+
+    #[test]
     fn pinning_requires_the_viewer_to_acknowledge_that_document() {
         let previews = previews_in(PREVIEWS);
         let target = PreviewTarget {
             pane_id: "w4:p3".into(),
             tab_id: "w4:t3".into(),
+            origin_tab_id: "w4:t1".into(),
         };
         assert!(target_is_showing(&previews, &target, "/r/b.rs"));
         assert!(!target_is_showing(&previews, &target, "/r/other.rs"));


### PR DESCRIPTION
## Summary
- add a persisted 24?80 column sidebar-width setting and reapply it when the whole tab area changes
- wait for `tab.created` ensure locks on Unix and Windows, and return closed previews to their originating tab
- validate native clipboard command exit status, adopting the verifiable fix from @thecoldblooded's #33 without unconditional OSC 52 output

Fixes #31
Fixes #32

## Validation
- `cargo test` (188 library + 17 binary tests)
- `cargo clippy -- -D warnings`
- `bash -n scripts/ensure-sidebar.sh`
- independent Claude coordinator diff review: no blockers
