### PR TITLE
settings: 'Strict toggle' and 'Focus on open' for the toggle launchers

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,9 @@ A real tree, not a directory dump:
 - Dotfiles toggle, live refresh, and a hide command when you want the columns back.
 - Prefer the sidebar closed? Toggle "Auto-open sidebar" off in ⚙ Settings and it stays
   closed until you invoke the open-sidebar action yourself.
+- Want one key to mean open/close? "Strict toggle" in ⚙ Settings closes an open sidebar
+  even when it isn't focused, and "Focus on open" off docks it in the background so
+  focus stays in the pane you toggled from.
 - Prefer the tree on the other side? Toggle "Dock on the right" in ⚙ Settings; the choice
   persists for every future launch and auto-docked tab.
 - Prefer a different width? Adjust "Sidebar width" with `←`/`→` in ⚙ Settings. The column

--- a/plugins/herdr-sidebar/scripts/open-git.sh
+++ b/plugins/herdr-sidebar/scripts/open-git.sh
@@ -90,16 +90,25 @@ open_pane() {
   # the explorer/last-active decision, so with the unified sidebar off this
   # launcher opened an Explorer pane labeled "Source Control" (issue #14).
   # The Windows launcher (open-git.ps1) always passed the pin.
+  focus_open="$("$bin" --focus-on-open 2>/dev/null || echo on)"
   if [ "$needs_swap" = "true" ]; then
     "$herdr_bin" pane swap --source-pane "$np" --target-pane "$target" >/dev/null 2>&1 || true
+    if [ "$focus_open" != "on" ] && [ "$target" = "$fid" ]; then
+      # "Focus on open: off" (⚙ Settings): the panel docks in the
+      # background, but the swap drags focus onto its slot (focus follows
+      # the slot). Hand it back right away, the ensure hook's move.
+      "$herdr_bin" pane focus --direction right --pane "$np" >/dev/null 2>&1 || true
+    fi
   fi
   "$herdr_bin" pane run "$np" "herdr-sidebar --view git"
   "$herdr_bin" pane rename "$np" "Source Control" >/dev/null 2>&1 || true
   # Give the TUI time to stamp its identity token before hooks re-check.
   sleep 3
-  # herdr has no focus-by-id; a zoom on/off cycle focuses deterministically.
-  "$herdr_bin" pane zoom "$np" --on >/dev/null 2>&1 || true
-  "$herdr_bin" pane zoom "$np" --off
+  if [ "$focus_open" = "on" ]; then
+    # herdr has no focus-by-id; a zoom on/off cycle focuses deterministically.
+    "$herdr_bin" pane zoom "$np" --on >/dev/null 2>&1 || true
+    "$herdr_bin" pane zoom "$np" --off
+  fi
 }
 
 decision="OPEN"

--- a/plugins/herdr-sidebar/scripts/open-sidebar.sh
+++ b/plugins/herdr-sidebar/scripts/open-sidebar.sh
@@ -87,16 +87,25 @@ open_pane() {
 
   # Left docking swaps into the narrow left slot; right docking is already
   # in place. PATH makes the same bare launch work in any configured shell.
+  focus_open="$("$bin" --focus-on-open 2>/dev/null || echo on)"
   if [ "$needs_swap" = "true" ]; then
     "$herdr_bin" pane swap --source-pane "$np" --target-pane "$target" >/dev/null 2>&1 || true
+    if [ "$focus_open" != "on" ] && [ "$target" = "$fid" ]; then
+      # "Focus on open: off" (⚙ Settings): the sidebar docks in the
+      # background, but the swap drags focus onto the explorer slot (focus
+      # follows the slot). Hand it back right away, the ensure hook's move.
+      "$herdr_bin" pane focus --direction right --pane "$np" >/dev/null 2>&1 || true
+    fi
   fi
   "$herdr_bin" pane run "$np" "herdr-sidebar"
   "$herdr_bin" pane rename "$np" Explorer >/dev/null 2>&1 || true
   # Give the TUI time to stamp its identity token before hooks re-check.
   sleep 3
-  # herdr has no focus-by-id; a zoom on/off cycle focuses deterministically.
-  "$herdr_bin" pane zoom "$np" --on >/dev/null 2>&1 || true
-  "$herdr_bin" pane zoom "$np" --off
+  if [ "$focus_open" = "on" ]; then
+    # herdr has no focus-by-id; a zoom on/off cycle focuses deterministically.
+    "$herdr_bin" pane zoom "$np" --on >/dev/null 2>&1 || true
+    "$herdr_bin" pane zoom "$np" --off
+  fi
 }
 
 decision="OPEN"

--- a/plugins/herdr-sidebar/src/ensure.rs
+++ b/plugins/herdr-sidebar/src/ensure.rs
@@ -53,10 +53,11 @@ use crate::snooze;
 /// focus, and respecting a tab the user toggled closed. Toggle mode (the
 /// action): open-or-focus-or-close, like VS Code's explorer shortcut.
 pub fn run(toggle: bool) -> std::io::Result<()> {
+    let state = crate::state::load_state();
     // Auto-open off (⚙ Settings): hooks leave closed tabs alone; the user's
     // explicit toggle still works. The unix hook script makes the same check
     // via `herdr-sidebar --auto-open`.
-    if !toggle && !crate::state::load_state().auto_open {
+    if !toggle && !state.auto_open {
         return Ok(());
     }
     let event_json = std::env::var("HERDR_PLUGIN_EVENT_JSON").unwrap_or_default();
@@ -82,7 +83,15 @@ pub fn run(toggle: bool) -> std::io::Result<()> {
     match launch::launch_decision_in(&panes, now, &scope).split_once(' ') {
         Some(("FOCUS", id)) => {
             if toggle {
-                focus(id)?;
+                if state.strict_toggle {
+                    // Strict toggle (⚙ Settings): one press opens, the next
+                    // press closes, wherever focus is. The unix launchers get
+                    // the same mapping from the --launch-decision CLI mode.
+                    ipc::call_text("pane.close", serde_json::json!({ "pane_id": id }))?;
+                    snooze::set(&snooze_dir, &tab);
+                } else {
+                    focus(id)?;
+                }
             }
         }
         Some(("CLOSE", id)) => {
@@ -99,12 +108,14 @@ pub fn run(toggle: bool) -> std::io::Result<()> {
             // id. Re-plan from a fresh snapshot rather than splitting a pane
             // that no longer exists.
             panes = ipc::call_text("pane.list", serde_json::json!({}))?;
-            open(&panes, toggle, &scope)?;
+            open(&panes, toggle && state.focus_on_open, &scope)?;
         }
         _ => {
             if toggle {
                 snooze::clear(&snooze_dir, &tab);
-                open(&panes, true, &scope)?;
+                // "Focus on open: off" (⚙ Settings) docks in the background:
+                // open()'s quiet path already hands focus back after the swap.
+                open(&panes, state.focus_on_open, &scope)?;
             } else if !snooze::is_set(&snooze_dir, &tab) {
                 open(&panes, false, &scope)?;
             }

--- a/plugins/herdr-sidebar/src/explorer_app.rs
+++ b/plugins/herdr-sidebar/src/explorer_app.rs
@@ -182,6 +182,8 @@ enum Setting {
     SidebarWidth,
     IconTheme,
     AutoOpen,
+    StrictToggle,
+    FocusOnOpen,
     FollowCwd,
     HiddenFiles,
     Hotkeys,
@@ -1164,6 +1166,28 @@ impl App {
                 true,
             ),
             (
+                Setting::StrictToggle,
+                "Strict toggle",
+                if self.sidebar_state.strict_toggle {
+                    "on"
+                } else {
+                    "off"
+                }
+                .to_string(),
+                true,
+            ),
+            (
+                Setting::FocusOnOpen,
+                "Focus on open",
+                if self.sidebar_state.focus_on_open {
+                    "on"
+                } else {
+                    "off"
+                }
+                .to_string(),
+                true,
+            ),
+            (
                 Setting::FollowCwd,
                 "Follow pane folder",
                 sidebar::follow_cwd_setting_value(self.sidebar_state.follow_cwd),
@@ -1220,6 +1244,14 @@ impl App {
             Setting::AutoOpen => {
                 self.sidebar_state =
                     sidebar::update_state(|state| state.auto_open = !state.auto_open);
+            }
+            Setting::StrictToggle => {
+                self.sidebar_state =
+                    sidebar::update_state(|state| state.strict_toggle = !state.strict_toggle);
+            }
+            Setting::FocusOnOpen => {
+                self.sidebar_state =
+                    sidebar::update_state(|state| state.focus_on_open = !state.focus_on_open);
             }
             Setting::FollowCwd => {
                 self.sidebar_state =

--- a/plugins/herdr-sidebar/src/launch.rs
+++ b/plugins/herdr-sidebar/src/launch.rs
@@ -291,6 +291,17 @@ pub fn launch_decision_in(pane_list_json: &str, now: u64, scope: &str) -> String
     }
 }
 
+/// Strict-toggle mapping (⚙ Settings): a `FOCUS` decision becomes `CLOSE`,
+/// so one toggle press opens and the next press closes, wherever focus is.
+/// Every other decision passes through untouched; kept pure so both the CLI
+/// mode and the Windows ensure sidecar share one tested mapping.
+pub fn focus_as_close(decision: &str) -> String {
+    match decision.split_once(' ') {
+        Some(("FOCUS", id)) => format!("CLOSE {id}"),
+        _ => decision.to_string(),
+    }
+}
+
 /// Source-control identity for the separated Source Control pane.
 pub const SC_PANE_LABEL: &str = "Source Control";
 pub const SC_METADATA_SOURCE: &str = "herdr-sidebar-git";
@@ -831,6 +842,17 @@ fn strip_verbatim(path: &str) -> &str {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Strict toggle rewrites only the FOCUS decision; OPEN, CLOSE, and
+    /// REPLACE (and garbage) must reach the launchers untouched.
+    #[test]
+    fn strict_toggle_maps_focus_to_close_and_nothing_else() {
+        assert_eq!(focus_as_close("FOCUS w4:p2"), "CLOSE w4:p2");
+        assert_eq!(focus_as_close("OPEN"), "OPEN");
+        assert_eq!(focus_as_close("CLOSE w4:p2"), "CLOSE w4:p2");
+        assert_eq!(focus_as_close("REPLACE w4:p2"), "REPLACE w4:p2");
+        assert_eq!(focus_as_close(""), "");
+    }
 
     /// The decision and the dock must reason about the SAME tab. Scoping only
     /// the spawn cwd would let the decision see a focused tab with no sidebar,

--- a/plugins/herdr-sidebar/src/main.rs
+++ b/plugins/herdr-sidebar/src/main.rs
@@ -33,11 +33,18 @@ fn main() -> std::io::Result<()> {
             // answers for one tab while the dock lands in another.
             let now = state::unix_now();
             let scope = std::env::args().nth(3).unwrap_or_default();
-            let out = if std::env::args().nth(2).as_deref() == Some("git") {
+            let mut out = if std::env::args().nth(2).as_deref() == Some("git") {
                 launch::launch_decision_git(&read_stdin()?, now)
             } else {
                 launch::launch_decision_in(&read_stdin()?, now, &scope)
             };
+            // Strict toggle (⚙ Settings): report an open-but-unfocused pane
+            // as CLOSE so the toggle launchers close it instead of focusing
+            // it first. Safe for the ensure hook, which ignores FOCUS and
+            // CLOSE alike (it only acts on OPEN and REPLACE).
+            if state::load_state().strict_toggle {
+                out = launch::focus_as_close(&out);
+            }
             println!("{out}");
             return Ok(());
         }
@@ -83,6 +90,13 @@ fn main() -> std::io::Result<()> {
             println!("{}", if state::load_state().auto_open { "on" } else { "off" });
             return Ok(());
         }
+        Some("--focus-on-open") => {
+            // For the unix toggle launchers: skip the open-then-focus zoom
+            // cycle when the user turned "Focus on open" off in ⚙ Settings,
+            // so the sidebar docks in the background.
+            println!("{}", if state::load_state().focus_on_open { "on" } else { "off" });
+            return Ok(());
+        }
         Some("--dock-right") => {
             println!("{}", if state::load_state().dock_right { "right" } else { "left" });
             return Ok(());
@@ -104,7 +118,7 @@ fn main() -> std::io::Result<()> {
         Some(other) => {
             eprintln!("herdr-sidebar: unknown argument `{other}`");
             eprintln!(
-                "usage: herdr-sidebar [--view explorer|git|--preview [ctl]|--launch-decision [git]|--focused-pane|--pane-has-token <id>|--open-plan|--focused-tab|--auto-open|--dock-right]"
+                "usage: herdr-sidebar [--view explorer|git|--preview [ctl]|--launch-decision [git]|--focused-pane|--pane-has-token <id>|--open-plan|--focused-tab|--auto-open|--focus-on-open|--dock-right]"
             );
             std::process::exit(2);
         }

--- a/plugins/herdr-sidebar/src/scm_app.rs
+++ b/plugins/herdr-sidebar/src/scm_app.rs
@@ -413,6 +413,8 @@ enum Setting {
     SidebarWidth,
     IconTheme,
     AutoOpen,
+    StrictToggle,
+    FocusOnOpen,
     FollowCwd,
     GitDecorations,
     Hotkeys,
@@ -1761,6 +1763,28 @@ impl App {
                 true,
             ),
             (
+                Setting::StrictToggle,
+                "Strict toggle",
+                if self.sidebar_state.strict_toggle {
+                    "on"
+                } else {
+                    "off"
+                }
+                .to_string(),
+                true,
+            ),
+            (
+                Setting::FocusOnOpen,
+                "Focus on open",
+                if self.sidebar_state.focus_on_open {
+                    "on"
+                } else {
+                    "off"
+                }
+                .to_string(),
+                true,
+            ),
+            (
                 Setting::FollowCwd,
                 "Follow pane folder",
                 sidebar::follow_cwd_setting_value(self.sidebar_state.follow_cwd),
@@ -1816,6 +1840,14 @@ impl App {
             Setting::AutoOpen => {
                 self.sidebar_state =
                     sidebar::update_state(|state| state.auto_open = !state.auto_open);
+            }
+            Setting::StrictToggle => {
+                self.sidebar_state =
+                    sidebar::update_state(|state| state.strict_toggle = !state.strict_toggle);
+            }
+            Setting::FocusOnOpen => {
+                self.sidebar_state =
+                    sidebar::update_state(|state| state.focus_on_open = !state.focus_on_open);
             }
             Setting::FollowCwd => {
                 self.sidebar_state =

--- a/plugins/herdr-sidebar/src/state.rs
+++ b/plugins/herdr-sidebar/src/state.rs
@@ -153,6 +153,13 @@ pub struct State {
     /// open-sidebar toggle themselves (issue #8); the explicit toggle always
     /// works regardless.
     pub auto_open: bool,
+    /// The open-sidebar toggle treats an open-but-unfocused sidebar as CLOSE
+    /// instead of FOCUS: one press opens, the next press closes, wherever
+    /// focus is. Off keeps the historical open / focus / close cycle.
+    pub strict_toggle: bool,
+    /// Focus the sidebar once the toggle opens it. Off docks it in the
+    /// background: focus stays in the pane the toggle was invoked from.
+    pub focus_on_open: bool,
     /// Follow the live foreground cwd of a non-sidebar pane in this tab.
     /// Manual folder choices win until an already-observed pane changes cwd.
     pub follow_cwd: bool,
@@ -178,6 +185,8 @@ impl Default for State {
             icons: None,
             font_prompt_done: false,
             auto_open: true,
+            strict_toggle: false,
+            focus_on_open: true,
             follow_cwd: true,
             git_deco: true,
             dock_right: false,
@@ -318,12 +327,14 @@ fn write_state(path: &Path, state: State) {
         None => String::new(),
     };
     let json = format!(
-        "{{\"merged\":{},\"active\":\"{}\",\"hotkeys\":{},\"font_prompt\":{},\"auto_open\":{},\"follow_cwd\":{},\"git_deco\":{},\"dock_right\":{},\"sidebar_width\":{}{icons}}}",
+        "{{\"merged\":{},\"active\":\"{}\",\"hotkeys\":{},\"font_prompt\":{},\"auto_open\":{},\"strict_toggle\":{},\"focus_on_open\":{},\"follow_cwd\":{},\"git_deco\":{},\"dock_right\":{},\"sidebar_width\":{}{icons}}}",
         state.merged,
         state.active.state_name(),
         state.show_hotkeys,
         state.font_prompt_done,
         state.auto_open,
+        state.strict_toggle,
+        state.focus_on_open,
         state.follow_cwd,
         state.git_deco,
         state.dock_right,
@@ -690,6 +701,14 @@ pub fn parse_state(json: &str) -> State {
             .get("auto_open")
             .and_then(|v| v.as_bool())
             .unwrap_or(default.auto_open),
+        strict_toggle: value
+            .get("strict_toggle")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(default.strict_toggle),
+        focus_on_open: value
+            .get("focus_on_open")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(default.focus_on_open),
         follow_cwd: value
             .get("follow_cwd")
             .and_then(|v| v.as_bool())
@@ -818,17 +837,23 @@ mod tests {
             icons: Some(crate::icons::IconTheme::Emoji),
             font_prompt_done: true,
             auto_open: false,
+            strict_toggle: true,
+            focus_on_open: false,
             follow_cwd: false,
             git_deco: false,
             dock_right: true,
             sidebar_width: 44,
         };
-        let json = "{\"merged\":true,\"active\":\"source-control\",\"hotkeys\":true,\"font_prompt\":true,\"auto_open\":false,\"follow_cwd\":false,\"git_deco\":false,\"dock_right\":true,\"sidebar_width\":44,\"icons\":\"emoji\"}";
+        let json = "{\"merged\":true,\"active\":\"source-control\",\"hotkeys\":true,\"font_prompt\":true,\"auto_open\":false,\"strict_toggle\":true,\"focus_on_open\":false,\"follow_cwd\":false,\"git_deco\":false,\"dock_right\":true,\"sidebar_width\":44,\"icons\":\"emoji\"}";
         assert_eq!(parse_state(json), state);
         assert!(parse_state("\u{feff}{\"merged\":true}").merged);
         // Files written before the flag existed keep auto-open AND the git
         // decorations on.
         assert!(parse_state("{\"merged\":true}").auto_open);
+        // Files written before the toggle settings existed keep the
+        // historical toggle behavior: focus an open sidebar, focus on open.
+        assert!(!parse_state("{\"merged\":true}").strict_toggle);
+        assert!(parse_state("{\"merged\":true}").focus_on_open);
         // Existing installs get neighbour following by default.
         assert!(parse_state("{\"merged\":true}").follow_cwd);
         assert!(parse_state("{\"merged\":true}").git_deco);


### PR DESCRIPTION
Two small quality-of-life settings for people who drive the sidebar from a single keybinding. Both are persisted flags (missing-field-safe), default to today's behavior, and show up in the ⚙ Settings modal of both views.

## Strict toggle

The open-sidebar action currently cycles open -> focus -> close, so an open-but-unfocused sidebar needs two presses to close. With **Strict toggle** on, one press opens and the next press closes, wherever focus is.

- The mapping is a pure `launch::focus_as_close` (FOCUS -> CLOSE, everything else untouched), shared by the `--launch-decision` CLI mode and the Windows ensure sidecar, with a unit test.
- The ensure hook is unaffected: it ignores FOCUS and CLOSE alike, so the mapping cannot make a hook close anything.

## Focus on open

With **Focus on open** off, the toggle docks the sidebar in the background: focus stays in the pane you toggled from.

- Unix launchers ask via the new `--focus-on-open` mode, skip the end-of-open zoom-focus cycle, and hand the swap-stolen focus straight back with the same directional-focus move the ensure hook already uses. The token-stamp wait and lock handling are untouched.
- The Windows ensure reuses its quiet-mode open, which already restores focus after the swap.

## Verified

- `cargo test` (state roundtrip updated, new mapping test) and `cargo clippy -- -D warnings` clean.
- Live on macOS + herdr 0.8.2: defaults reproduce today's behavior exactly (open focuses the sidebar; focused sidebar closes); with both settings flipped, the sidebar opens in the background with focus kept, and a single unfocused press closes it. `--focus-on-open` reports on/off; FOCUS/CLOSE/REPLACE/OPEN pass through untouched when strict is off.