### PR TITLE
feat: ship verified prebuilts and terminal-adaptive colors

### DIFF
--- a/.github/ruleset-main.json
+++ b/.github/ruleset-main.json
@@ -20,7 +20,8 @@
         "required_status_checks": [
           { "context": "build + test + clippy (windows-latest)" },
           { "context": "build + test + clippy (ubuntu-latest)" },
-          { "context": "build + test + clippy (macos-latest)" }
+          { "context": "build + test + clippy (macos-latest)" },
+          { "context": "maintainer-only command paths" }
         ] } }
   ]
 }

--- a/.github/workflows/agent-command-guard.yml
+++ b/.github/workflows/agent-command-guard.yml
@@ -1,0 +1,27 @@
+name: Reject agent commands
+
+on:
+  pull_request_target:
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  reject:
+    name: maintainer-only command paths
+    runs-on: ubuntu-latest
+    steps:
+      - name: Reject contributed agent commands
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          files=$(gh api --paginate "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/files" --jq '.[].filename')
+          blocked=$(printf '%s\n' "$files" |
+            grep -Ei '^\.claude/commands($|/)|^\.codex/prompts($|/)' || true)
+          if [ -n "$blocked" ]; then
+            echo "Maintainer-only agent commands cannot be contributed:" >&2
+            echo "$blocked" >&2
+            exit 1
+          fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,12 +18,31 @@ jobs:
         working-directory: plugins/herdr-sidebar
     steps:
       - uses: actions/checkout@v7
+      - name: Reject tracked maintainer-only agent commands
+        working-directory: .
+        shell: bash
+        run: |
+          tracked=$(git ls-files |
+            grep -Ei '^\.claude/commands($|/)|^\.codex/prompts($|/)' || true)
+          if [ -n "$tracked" ]; then
+            echo "Maintainer-only agent commands must remain local and ignored:" >&2
+            echo "$tracked" >&2
+            exit 1
+          fi
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: plugins/herdr-sidebar
+      - name: Test prebuilt installer (Windows)
+        if: runner.os == 'Windows'
+        shell: powershell
+        run: .\scripts\test-fetch-or-build.ps1
+      - name: Test prebuilt installer (Unix)
+        if: runner.os != 'Windows'
+        shell: bash
+        run: sh scripts/test-fetch-or-build.sh
       - run: cargo build --release
       - run: cargo test
       - run: cargo clippy --release -- -D warnings

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,92 @@
+name: Release binaries
+
+on:
+  push:
+    tags: ["v*"]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: build ${{ matrix.triple }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: windows-latest
+            triple: x86_64-pc-windows-msvc
+          - os: ubuntu-latest
+            triple: x86_64-unknown-linux-musl
+          - os: macos-latest
+            triple: x86_64-apple-darwin
+          - os: macos-latest
+            triple: aarch64-apple-darwin
+    runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        working-directory: plugins/herdr-sidebar
+    steps:
+      - uses: actions/checkout@v7
+      - name: Verify tag and manifest versions
+        shell: bash
+        run: |
+          version="${GITHUB_REF_NAME#v}"
+          crate=$(grep -E '^version *= *"' Cargo.toml | head -n1 | sed -E 's/^version *= *"([^"]+)".*/\1/')
+          manifest=$(grep -E '^version *= *"' herdr-plugin.toml | head -n1 | sed -E 's/^version *= *"([^"]+)".*/\1/')
+          lock=$(awk '/^name = "herdr-sidebar"$/ { getline; sub(/^version = "/, ""); sub(/"$/, ""); print; exit }' Cargo.lock)
+          test "$version" = "$crate"
+          test "$version" = "$manifest"
+          test "$version" = "$lock"
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.triple }}
+      - name: Install musl linker
+        if: matrix.triple == 'x86_64-unknown-linux-musl'
+        run: sudo apt-get update && sudo apt-get install -y musl-tools
+      - name: Build release binaries
+        run: cargo build --release --target ${{ matrix.triple }} --bins
+      - name: Stage assets and checksums
+        shell: bash
+        run: |
+          set -eu
+          mkdir -p dist
+          triple="${{ matrix.triple }}"
+          suffix=""
+          if [[ "$triple" == *windows* ]]; then suffix=".exe"; fi
+          cp "target/$triple/release/herdr-sidebar$suffix" "dist/herdr-sidebar-$triple$suffix"
+          if [[ "$triple" == *windows* ]]; then
+            cp "target/$triple/release/herdr-sidebar-ensure.exe" "dist/herdr-sidebar-ensure-$triple.exe"
+          fi
+          cd dist
+          for file in herdr-sidebar-*; do
+            if command -v sha256sum >/dev/null 2>&1; then sha256sum "$file"; else shasum -a 256 "$file"; fi
+          done > CHECKSUMS.part
+      - uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.triple }}
+          path: plugins/herdr-sidebar/dist/*
+
+  publish:
+    name: publish assets
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+      - name: Assemble release files
+        run: |
+          mkdir release
+          find artifacts -type f ! -name 'CHECKSUMS.part' -exec cp {} release/ \;
+          cat artifacts/*/CHECKSUMS.part > release/SHA256SUMS
+      - name: Create or update GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release view "$GITHUB_REF_NAME" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1 || \
+            gh release create "$GITHUB_REF_NAME" --repo "$GITHUB_REPOSITORY" --title "$GITHUB_REF_NAME" --generate-notes --draft
+          gh release upload "$GITHUB_REF_NAME" release/* --clobber --repo "$GITHUB_REPOSITORY"
+          gh release edit "$GITHUB_REF_NAME" --draft=false --repo "$GITHUB_REPOSITORY"

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 target/
 .claude/worktrees/
 .claude/settings.local.json
+/.claude/commands/
+/.codex/prompts/
 __pycache__/
 tools/screenshots/attach.log

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,6 +32,10 @@ cargo test
 cargo clippy -- -D warnings
 ```
 
+`plugins/herdr-sidebar/scripts/.gitattributes` pins every shell script to LF. The
+repository has Windows contributors and `core.autocrlf` is common, but these files are
+executed by Bash on Linux/macOS and mixed or CRLF endings fail before the launcher runs.
+
 ## Plugin dev workflow
 
 - `herdr plugin link .` (from the plugin dir) registers the local checkout with the running
@@ -99,6 +103,9 @@ cargo clippy -- -D warnings
   Explorer/Source Control/Sidebar panes in every workspace, reaps only the ensure sidecar, and
   re-docks the focused workspace; preview/editor panes survive so unsaved buffers are preserved.
   The others re-dock via the focus hook the moment they're next visited.
+- Toggle-behavior settings have three platform launch paths to keep aligned: the Windows unified
+  sidecar (`ensure.rs`), the Windows separated Source Control launcher (`open-git.ps1`), and both
+  Unix launchers. Updating only the sidecar makes the same setting behave differently by view.
 - **os error 5 can come from ANOTHER Windows account**: if a second account's herdr session
   runs sidebar panes from this same checkout, its processes show empty Path/StartTime in
   `Get-Process`, `Stop-Process` fails silently on them, and redeploy from this account can't
@@ -110,16 +117,28 @@ cargo clippy -- -D warnings
 - Bump the version in THREE files: `Cargo.toml`, `herdr-plugin.toml`, and `Cargo.lock`
   (any cargo command regenerates the lock entry). Commit as `vX.Y.Z`, `git tag vX.Y.Z`,
   push branch + tag.
-- **Pushing a tag alone does NOT update the repo's "Latest" release badge** — also run
-  `gh release create vX.Y.Z --title vX.Y.Z --notes-file <md>`. House style for notes: a
-  headline `##`, Fixes/New sections referencing issue/PR numbers and crediting contributor
-  handles, and the `herdr plugin install alexarthurs/herdr-sidebar/plugins/herdr-sidebar`
-  snippet at the end.
+- Pushing the tag triggers `.github/workflows/release.yml`, which creates or updates the GitHub
+  release and uploads SHA-256-verified prebuilt assets. Wait for that workflow before announcing
+  the release; edit its generated notes to the house style (headline, Fixes/New sections with
+  issue/PR credit, and the install snippet) rather than creating a competing release manually.
+- Prebuilt selection is version-based and checksum-verified. Windows needs BOTH the main binary
+  and the GUI-subsystem ensure sidecar; a partial download must fall back to the source build.
+- Release assets use `herdr-sidebar[-ensure]-<rust-target>[.exe]` plus `SHA256SUMS`.
+  Platform-gated `[[build]]` entries fetch only the crate's declared version, verify before
+  moving either binary into `target/release`, and fall back to `cargo build --release` for
+  unsupported targets, missing assets, or mismatches. The `HS_*` seams are enabled only by
+  `HS_TEST_MODE=1`; never make production download origin or executable selection env-driven.
 - Merging contributor PRs locally (`git fetch origin pull/N/head:pr-N`, `git merge --no-ff
   pr-N`, push main) marks them MERGED on GitHub, and `Fixes #N`/`Closes #N` in commit
   messages auto-close the issues on push. Branch protection ("changes must be made through
   a pull request") is bypassable as repo admin — the push prints a rule-violation warning
   but succeeds.
+- Before merging fetched contributor commits, inspect `gh pr diff N --name-only | rg -i
+  '^\.(claude|codex)/|^CLAUDE\.md$|^\.github/workflows/'` for agent instructions and
+  workflow changes. `.claude/commands/` and `.codex/prompts/` are
+  maintainer-local, ignored, rejected by ordinary CI, and independently rejected by a
+  `pull_request_target` workflow that never checks out contributor code. A PR can still alter
+  `CLAUDE.md`, tracked skills, or workflows, so review those paths as instructions, not data.
 
 ### Testing hooks headless (no TUI attached)
 
@@ -154,8 +173,9 @@ Pane geometry & CLI semantics:
   sidebar HIDES (closes) rather than collapsing to a sliver. (Panes inside a NESTED split can be narrower than 10% of the
   window — the floor is per-split-rect — but the sidebar's column is a root-split child.)
 - There is no focus-by-id; focusing a pane is a `pane zoom <id> --on` / `--off` cycle.
-- `pane send-keys` accepts only a limited key-name set: `Up`/`Down`/`Enter`/`Escape`/`Tab`
-  and plain characters work, but `Home` is rejected with `invalid_key` and
+- `pane send-keys` accepts only a limited key-name set: `Up`/`Down`/`Enter`/`Escape`/`Tab`,
+  lowercase modifier chords such as `ctrl+q`, and plain characters work, but `Home` is
+  rejected with `invalid_key` and
   `PageDown`/`PgDn`/`page-down`/`pgdn` are all rejected as unsupported too. Give TUIs
   single-char fallbacks (`g`/`G` for Home/End) so they stay drivable via send-keys.
 - A `pane list` snapshot goes stale the moment you `pane close` a pane: if the closed pane
@@ -224,6 +244,12 @@ e.g. `"ctrl"` → Ctrl+right-click reaches the app with ctrl stripped; a modifie
 plain-right-click passthrough is not supported). Same-tab `pane.move` is a deliberate no-op
 (`SameTab`) — restructure within a tab by bouncing the pane through `--new-tab` and back
 (herdr auto-closes the emptied temp tab).
+
+Plugin panes cannot read herdr's private UI palette. The `terminal` color theme therefore uses
+ANSI named colors that inherit the terminal profile; `vscode` remains the compatibility default
+with the historical fixed RGB values. Terminal selections use reverse-video instead of forcing a
+dark background, so light profiles remain readable. Keep every shared accent in `ui::Palette`
+so Explorer and Source Control cannot drift.
 
 Pane identity & titles:
 
@@ -378,8 +404,13 @@ HACKING.md — budget time for that before promising a patched build.
 - **`pane close` kills the TUI process with no chance to flush** (no signal/console-close
   it can catch in practice) — any debounced-autosave state inside the debounce window dies
   with it. Toggle-off launchers should first drive a graceful save+quit via
-  `pane send-keys <id> Escape q` (design the keymap so Esc-then-q saves and quits from
-  every mode), short sleep, THEN `pane close` as the cleanup.
+  `pane send-keys <id> ctrl+q`, poll until the identity token disappears, THEN
+  `pane close` as cleanup. Probe errors and save failures keep the live pane open rather
+  than treating uncertainty as acknowledgement, and explicit toggles surface a notification
+  instead of failing silently. Ctrl+Q is a
+  dedicated quit chord handled before overlays/focus modes; do not use Escape, which closes
+  a tab-scoped preview/editor. SCM snapshots include commit drafts keyed by repo root, so
+  graceful quit and ordinary `q` restore unfinished text on the next Source Control pane.
 
 ### Unified sidebar (see `src/state.rs`)
 
@@ -403,6 +434,10 @@ HACKING.md — budget time for that before promising a patched build.
 - Every Settings action uses `state::update_state`, a lock-protected read-modify-write.
   Never write an app's startup snapshot wholesale: preview tabs run independent sidebar
   processes, and a stale snapshot silently reverts newer settings from another tab.
+- Separated Explorer and Source Control panes periodically re-read shared display settings,
+  including `color_theme`, `strict_toggle`, and `focus_on_open`; theme changes also update
+  the process palette immediately. The Settings modal scrolls to keep its selected row visible
+  when the pane is too short for all rows and hotkey hints.
 - `dock_right` in the same state file (default false) drives the “Dock on the right” Settings
   row. Launch target/ratio/swap, resize direction, and full-height repair all mirror from that
   one persisted choice. Preview tabs inherit it when the `tab.created` hook docks their sidebar.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -247,9 +247,10 @@ plain-right-click passthrough is not supported). Same-tab `pane.move` is a delib
 
 Plugin panes cannot read herdr's private UI palette. The `terminal` color theme therefore uses
 ANSI named colors that inherit the terminal profile; `vscode` remains the compatibility default
-with the historical fixed RGB values. Terminal selections use reverse-video instead of forcing a
-dark background, so light profiles remain readable. Keep every shared accent in `ui::Palette`
-so Explorer and Source Control cannot drift.
+with the historical fixed RGB values. Terminal selections use ANSI `DarkGray`/`White`, not
+reverse-video: reverse also swaps per-span git decoration colors and turns a green status dot into
+a green background block. Keep every shared accent in `ui::Palette` so Explorer and Source Control
+cannot drift.
 
 Pane identity & titles:
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,9 @@ entirely by click or keystroke.
 herdr plugin install alexarthurs/herdr-sidebar/plugins/herdr-sidebar
 ```
 
+Tagged releases install SHA-256-verified prebuilt binaries on supported Windows, macOS,
+and Linux systems. Unsupported targets or unavailable assets fall back to a source build.
+
 ---
 
 ## One pane. Two views. Zero friction.
@@ -97,6 +100,8 @@ A real tree, not a directory dump:
   persists for every future launch and auto-docked tab.
 - Prefer a different width? Adjust "Sidebar width" with `←`/`→` in ⚙ Settings. The column
   target persists and is re-applied when the surrounding tab width changes.
+- Prefer your terminal's palette? Switch "Color theme" to `terminal`; ANSI accents then
+  follow the terminal profile while `vscode` preserves the original fixed RGB colors.
 
 ### 🔀 Source Control
 

--- a/README.md
+++ b/README.md
@@ -90,6 +90,9 @@ A real tree, not a directory dump:
 - Dotfiles toggle, live refresh, and a hide command when you want the columns back.
 - Prefer the sidebar closed? Toggle "Auto-open sidebar" off in ⚙ Settings and it stays
   closed until you invoke the open-sidebar action yourself.
+- Want one key to mean open/close? "Strict toggle" in ⚙ Settings closes an open sidebar
+  even when it isn't focused, and "Focus on open" off docks it in the background so
+  focus stays in the pane you toggled from.
 - Prefer the tree on the other side? Toggle "Dock on the right" in ⚙ Settings; the choice
   persists for every future launch and auto-docked tab.
 - Prefer a different width? Adjust "Sidebar width" with `←`/`→` in ⚙ Settings. The column

--- a/plugins/herdr-sidebar/Cargo.lock
+++ b/plugins/herdr-sidebar/Cargo.lock
@@ -550,7 +550,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "herdr-sidebar"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "crossterm",
  "ratatui",

--- a/plugins/herdr-sidebar/Cargo.toml
+++ b/plugins/herdr-sidebar/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "herdr-sidebar"
-version = "0.9.0"
+version = "0.10.0"
 edition = "2024"
 description = "VS Code-style sidebar for herdr: file explorer + source control in one pane"
 license = "MIT"

--- a/plugins/herdr-sidebar/herdr-plugin.toml
+++ b/plugins/herdr-sidebar/herdr-plugin.toml
@@ -18,13 +18,18 @@
 
 id = "herdr-sidebar"
 name = "herdr-sidebar"
-version = "0.9.0"
+version = "0.10.0"
 description = "VS Code-style sidebar: file explorer + source control (with ✧ AI commit messages) in one herdr pane."
 min_herdr_version = "0.8.0"
 platforms = ["linux", "macos", "windows"]
 
 [[build]]
-command = ["cargo", "build", "--release"]
+platforms = ["linux", "macos"]
+command = ["/bin/sh", "scripts/fetch-or-build.sh"]
+
+[[build]]
+platforms = ["windows"]
+command = ["powershell", "-NoProfile", "-ExecutionPolicy", "Bypass", "-File", "scripts/fetch-or-build.ps1"]
 
 # Declarative pane entry — usable on linux/macos (`plugin pane open`) and as
 # the unix launcher's fallback. No Windows [[panes]] entry: the relative

--- a/plugins/herdr-sidebar/scripts/.gitattributes
+++ b/plugins/herdr-sidebar/scripts/.gitattributes
@@ -1,0 +1,1 @@
+*.sh text eol=lf

--- a/plugins/herdr-sidebar/scripts/fetch-or-build.ps1
+++ b/plugins/herdr-sidebar/scripts/fetch-or-build.ps1
@@ -1,0 +1,97 @@
+# Install verified Windows release binaries, falling back to cargo on any miss.
+# Compatible with the Windows PowerShell 5.1 host used by herdr actions.
+$ErrorActionPreference = 'Stop'
+
+$Repo = 'alexarthurs/herdr-sidebar'
+$TestMode = $env:HS_TEST_MODE -eq '1'
+function Remove-HsVerbatimPrefix([string]$Path) {
+    if ($Path -and $Path.StartsWith('\\?\')) { return $Path.Substring(4) }
+    return $Path
+}
+$NormalScriptRoot = Remove-HsVerbatimPrefix $PSScriptRoot
+$RepoRoot = if ($TestMode -and $env:HS_REPO_ROOT) { $env:HS_REPO_ROOT } else { [IO.Path]::GetFullPath((Join-Path $NormalScriptRoot '..')) }
+$CargoToml = if ($TestMode -and $env:HS_CARGO_TOML) { $env:HS_CARGO_TOML } else { Join-Path $RepoRoot 'Cargo.toml' }
+$OutDir = if ($TestMode -and $env:HS_OUT_DIR) { $env:HS_OUT_DIR } else { Join-Path $RepoRoot 'target\release' }
+$BaseUrl = if ($TestMode -and $env:HS_BASE_URL) { $env:HS_BASE_URL } else { "https://github.com/$Repo/releases/download" }
+$script:TmpDir = $null
+
+function Remove-HsTemp {
+    if ($script:TmpDir -and (Test-Path -LiteralPath $script:TmpDir)) {
+        Remove-Item -LiteralPath $script:TmpDir -Recurse -Force -ErrorAction SilentlyContinue
+    }
+}
+
+function Build-HsFromSource {
+    param([string]$Reason)
+    [Console]::Error.WriteLine("herdr-sidebar: $Reason; building from source instead.")
+    Remove-HsTemp
+    $Cargo = if ($TestMode -and $env:HS_CARGO) { $env:HS_CARGO } else { 'cargo' }
+    if (-not (Get-Command $Cargo -ErrorAction SilentlyContinue)) {
+        [Console]::Error.WriteLine('herdr-sidebar needs a matching prebuilt release or Rust from https://rustup.rs')
+        exit 1
+    }
+    Push-Location $RepoRoot
+    try {
+        & $Cargo build --release
+        exit $LASTEXITCODE
+    } finally {
+        Pop-Location
+    }
+}
+
+function Get-HsAsset {
+    param([string]$Name, [string]$Destination)
+    try {
+        if ($TestMode -and $env:HS_FETCH_DIR) {
+            Copy-Item -LiteralPath (Join-Path $env:HS_FETCH_DIR $Name) -Destination $Destination -Force
+        } else {
+            try {
+                [Net.ServicePointManager]::SecurityProtocol =
+                    [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12
+            } catch {}
+            Invoke-WebRequest -Uri "$BaseUrl/v$Version/$Name" -OutFile $Destination -UseBasicParsing
+        }
+        return $true
+    } catch {
+        return $false
+    }
+}
+
+$Arch = if ($TestMode -and $env:HS_ARCH) { $env:HS_ARCH } elseif ($env:PROCESSOR_ARCHITEW6432) { $env:PROCESSOR_ARCHITEW6432 } else { $env:PROCESSOR_ARCHITECTURE }
+if ($Arch -ne 'AMD64') { Build-HsFromSource "no prebuilt binary for Windows/$Arch" }
+$Triple = 'x86_64-pc-windows-msvc'
+
+$VersionMatch = Select-String -Path $CargoToml -Pattern '^version\s*=\s*"([^"]+)"' | Select-Object -First 1
+if (-not $VersionMatch) { Build-HsFromSource 'could not read the crate version' }
+$Version = $VersionMatch.Matches[0].Groups[1].Value
+
+$Assets = @(
+    "herdr-sidebar-$Triple.exe",
+    "herdr-sidebar-ensure-$Triple.exe"
+)
+$script:TmpDir = Join-Path ([IO.Path]::GetTempPath()) ("herdr-sidebar-fetch-" + [Guid]::NewGuid().ToString('N'))
+New-Item -ItemType Directory -Path $script:TmpDir -Force | Out-Null
+$Sums = Join-Path $script:TmpDir 'SHA256SUMS'
+if (-not (Get-HsAsset 'SHA256SUMS' $Sums)) { Build-HsFromSource "checksums are unavailable for v$Version" }
+
+foreach ($Asset in $Assets) {
+    $Downloaded = Join-Path $script:TmpDir $Asset
+    if (-not (Get-HsAsset $Asset $Downloaded)) { Build-HsFromSource "no prebuilt $Asset exists for v$Version" }
+    $Escaped = [regex]::Escape($Asset)
+    $Line = Get-Content -LiteralPath $Sums | Where-Object { $_ -match "^([0-9a-fA-F]{64}) [ *]${Escaped}$" } | Select-Object -First 1
+    if (-not $Line) { Build-HsFromSource "the release does not list a checksum for $Asset" }
+    $Expected = ([regex]::Match($Line, '^[0-9a-fA-F]{64}').Value).ToLowerInvariant()
+    try {
+        $Actual = (Get-FileHash -LiteralPath $Downloaded -Algorithm SHA256).Hash.ToLowerInvariant()
+    } catch {
+        Build-HsFromSource "could not calculate SHA-256 for $Asset"
+    }
+    if ($Actual -ne $Expected) { Build-HsFromSource "checksum verification failed for $Asset" }
+}
+
+New-Item -ItemType Directory -Path $OutDir -Force | Out-Null
+Move-Item -LiteralPath (Join-Path $script:TmpDir $Assets[0]) -Destination (Join-Path $OutDir 'herdr-sidebar.exe') -Force
+Move-Item -LiteralPath (Join-Path $script:TmpDir $Assets[1]) -Destination (Join-Path $OutDir 'herdr-sidebar-ensure.exe') -Force
+Remove-HsTemp
+[Console]::Out.WriteLine("herdr-sidebar: installed verified prebuilt v$Version ($Triple).")
+exit 0

--- a/plugins/herdr-sidebar/scripts/fetch-or-build.sh
+++ b/plugins/herdr-sidebar/scripts/fetch-or-build.sh
@@ -1,0 +1,100 @@
+#!/bin/sh
+# Install a release binary when one matches this checkout's declared version.
+# Any unsupported platform, download failure, or checksum mismatch falls back
+# to the historical source build instead of making installation less reliable.
+set -u
+
+repo="alexarthurs/herdr-sidebar"
+script_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+test_mode=${HS_TEST_MODE:-0}
+if [ "$test_mode" = 1 ]; then
+  repo_root=${HS_REPO_ROOT:-"$script_dir/.."}
+  cargo_toml=${HS_CARGO_TOML:-"$repo_root/Cargo.toml"}
+  out=${HS_OUT:-"$repo_root/target/release/herdr-sidebar"}
+  base_url=${HS_BASE_URL:-"https://github.com/$repo/releases/download"}
+else
+  repo_root="$script_dir/.."
+  cargo_toml="$repo_root/Cargo.toml"
+  out="$repo_root/target/release/herdr-sidebar"
+  base_url="https://github.com/$repo/releases/download"
+fi
+
+cleanup() {
+  [ -n "${tmpdir:-}" ] && rm -rf "$tmpdir"
+}
+
+build_from_source() {
+  cleanup
+  [ -f "$HOME/.cargo/env" ] && . "$HOME/.cargo/env"
+  if [ "$test_mode" = 1 ]; then cargo_bin=${HS_CARGO:-cargo}; else cargo_bin=cargo; fi
+  if ! command -v "$cargo_bin" >/dev/null 2>&1; then
+    echo "herdr-sidebar needs a matching prebuilt release or Rust from https://rustup.rs" >&2
+    exit 1
+  fi
+  cd "$repo_root" || exit 1
+  exec "$cargo_bin" build --release
+}
+
+fallback() {
+  echo "herdr-sidebar: $1; building from source instead." >&2
+  build_from_source
+}
+
+download() {
+  name=$1
+  dest=$2
+  if [ "$test_mode" = 1 ] && [ -n "${HS_FETCH_DIR:-}" ]; then
+    cp "$HS_FETCH_DIR/$name" "$dest" 2>/dev/null
+  elif command -v curl >/dev/null 2>&1; then
+    curl -fsSL -o "$dest" "$base_url/v$version/$name"
+  elif command -v wget >/dev/null 2>&1; then
+    wget -q -O "$dest" "$base_url/v$version/$name"
+  else
+    return 127
+  fi
+}
+
+sha256_of() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$1" | awk '{print $1}'
+  elif command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 "$1" | awk '{print $1}'
+  else
+    return 127
+  fi
+}
+
+if [ "$test_mode" = 1 ]; then
+  os=${HS_UNAME_S:-$(uname -s 2>/dev/null || echo unknown)}
+  arch=${HS_UNAME_M:-$(uname -m 2>/dev/null || echo unknown)}
+else
+  os=$(uname -s 2>/dev/null || echo unknown)
+  arch=$(uname -m 2>/dev/null || echo unknown)
+fi
+triple=""
+case "$os/$arch" in
+  Darwin/arm64|Darwin/aarch64) triple="aarch64-apple-darwin" ;;
+  Darwin/x86_64|Darwin/amd64) triple="x86_64-apple-darwin" ;;
+  Linux/x86_64|Linux/amd64) triple="x86_64-unknown-linux-musl" ;;
+esac
+[ -n "$triple" ] || fallback "no prebuilt binary for $os/$arch"
+
+version=$(grep -E '^version *= *"' "$cargo_toml" 2>/dev/null | head -n 1 | sed -E 's/^version *= *"([^"]+)".*/\1/')
+[ -n "$version" ] || fallback "could not read the crate version"
+
+asset="herdr-sidebar-$triple"
+tmpdir=$(mktemp -d 2>/dev/null) || fallback "could not create a temporary directory"
+trap cleanup EXIT
+download SHA256SUMS "$tmpdir/SHA256SUMS" || fallback "checksums are unavailable for v$version"
+download "$asset" "$tmpdir/$asset" || fallback "no prebuilt $asset exists for v$version"
+
+expected=$(grep -E "^[0-9a-fA-F]{64} [ *]$asset\$" "$tmpdir/SHA256SUMS" 2>/dev/null | awk '{print tolower($1)}' | head -n 1)
+[ -n "$expected" ] || fallback "the release does not list a checksum for $asset"
+actual=$(sha256_of "$tmpdir/$asset") || fallback "no SHA-256 utility is available"
+[ "$actual" = "$expected" ] || fallback "checksum verification failed for $asset"
+
+mkdir -p "$(dirname "$out")" || fallback "could not create the binary directory"
+chmod +x "$tmpdir/$asset"
+mv -f "$tmpdir/$asset" "$out" || fallback "could not install the verified binary"
+echo "herdr-sidebar: installed verified prebuilt v$version ($triple)."
+exit 0

--- a/plugins/herdr-sidebar/scripts/open-git.ps1
+++ b/plugins/herdr-sidebar/scripts/open-git.ps1
@@ -39,26 +39,86 @@ if (-not (Test-Path $Bin)) {
     exit 1
 }
 
+# Serialize with the ensure hook and Unix launchers. Without this, a focus
+# event can classify the pane between rename and its first identity token as a
+# corpse and replace it while this explicit toggle is still running.
+$LockDir = Join-Path ([IO.Path]::GetTempPath()) 'herdr-sidebar-ensure.lock'
+$Locked = $false
+for ($i = 0; $i -lt 20; $i++) {
+    try {
+        New-Item -ItemType Directory -Path $LockDir -ErrorAction Stop | Out-Null
+        $Locked = $true
+        break
+    } catch {
+        Start-Sleep -Milliseconds 500
+    }
+}
+if (-not $Locked) {
+    $lock = Get-Item -LiteralPath $LockDir -ErrorAction SilentlyContinue
+    if ($lock -and ((Get-Date) - $lock.LastWriteTime).TotalSeconds -ge 30) {
+        Remove-Item -LiteralPath $LockDir -Force -ErrorAction SilentlyContinue
+        try {
+            New-Item -ItemType Directory -Path $LockDir -ErrorAction Stop | Out-Null
+            $Locked = $true
+        } catch {}
+    }
+}
+if (-not $Locked) { exit 0 }
+
+try {
+
 # Extract the first `pane_id` from a herdr CLI JSON reply.
 function Get-PaneId([string]$json) {
     return ([regex]'"pane_id":"([^"]+)"').Match($json).Groups[1].Value
 }
 
 $PanesJson = (& $HerdrBin pane list | Out-String)
+$FocusOnOpen = ((& $Bin --focus-on-open 2>$null) | Out-String).Trim()
+if (-not $FocusOnOpen) { $FocusOnOpen = 'on' }
+
+function Close-PaneGracefully([string]$PaneId) {
+    & $HerdrBin pane send-keys $PaneId ctrl+q *> $null
+    $Acknowledged = $false
+    for ($i = 0; $i -lt 20; $i++) {
+        Start-Sleep -Milliseconds 100
+        $listed = (& $HerdrBin pane list 2>$null | Out-String)
+        $listedOk = $LASTEXITCODE -eq 0
+        $present = (($listed | & $Bin --pane-has-token $PaneId 2>$null) | Out-String).Trim()
+        $probeOk = $LASTEXITCODE -eq 0
+        if ($listedOk -and $probeOk -and $present -ne 'yes') {
+            $Acknowledged = $true
+            break
+        }
+    }
+    if ($Acknowledged) {
+        & $HerdrBin pane close $PaneId *> $null
+    } else {
+        & $HerdrBin notification show 'Sidebar close cancelled' `
+            --body 'The pane did not acknowledge a safe shutdown; try again shortly.' `
+            --position bottom-right --sound none *> $null
+    }
+}
 
 function Open-Pane {
     # Focused pane = where the user is working; its cwd picks the repository.
     $fp = ($PanesJson | & $Bin --focused-pane).Trim()
     if (-not $fp) {
         # No focused pane known: best-effort plain split beside the current pane.
-        $splitArgs = @('pane', 'split', '--current', '--direction', 'right', '--ratio', '0.75',
+        $splitArgs = @('pane', 'split', '--current', '--direction', 'right', '--ratio', '0.75', '--no-focus',
             '--env', "PATH=$LaunchPath")
         if ($env:HERDR_PLUGIN_STATE_DIR) {
             $splitArgs += @('--env', "HERDR_PLUGIN_STATE_DIR=$env:HERDR_PLUGIN_STATE_DIR")
         }
         $out = (& $HerdrBin @splitArgs | Out-String)
         $np = Get-PaneId $out
-        if ($np) { & $HerdrBin pane run $np 'herdr-sidebar --view git' }
+        if ($np) {
+            & $HerdrBin pane run $np 'herdr-sidebar --view git'
+            & $HerdrBin pane rename $np 'Source Control' *> $null
+            if ($FocusOnOpen -eq 'on') {
+                & $HerdrBin pane zoom $np --on *> $null
+                & $HerdrBin pane zoom $np --off *> $null
+            }
+        }
         exit 0
     }
     $FocusedId, $FocusedCwd = $fp -split "`t", 2
@@ -91,6 +151,11 @@ function Open-Pane {
     # in place. PATH makes the bare launch independent of the pane's shell.
     if ($NeedsSwap) {
         & $HerdrBin pane swap --source-pane $np --target-pane $Target *> $null
+        if ($FocusOnOpen -ne 'on' -and $Target -eq $FocusedId) {
+            # A left-dock swap moves focus with the slot. Restore the pane the
+            # user invoked the toggle from when background-open is enabled.
+            & $HerdrBin pane focus --direction right --pane $np *> $null
+        }
     }
     & $HerdrBin pane run $np 'herdr-sidebar --view git'
     & $HerdrBin pane rename $np 'Source Control' *> $null
@@ -102,9 +167,11 @@ function Open-Pane {
             Where-Object { $_.pane_id -eq $np }).tokens
         if ($tok) { break }
     }
-    # herdr has no focus-by-id; a zoom on/off cycle focuses deterministically.
-    & $HerdrBin pane zoom $np --on *> $null
-    & $HerdrBin pane zoom $np --off *> $null
+    if ($FocusOnOpen -eq 'on') {
+        # herdr has no focus-by-id; a zoom on/off cycle focuses deterministically.
+        & $HerdrBin pane zoom $np --on *> $null
+        & $HerdrBin pane zoom $np --off *> $null
+    }
     exit 0
 }
 
@@ -119,8 +186,8 @@ if ($Decision -like 'FOCUS *') {
     exit $LASTEXITCODE
 } elseif ($Decision -like 'CLOSE *') {
     $PaneId = $Decision.Substring(6)
-    & $HerdrBin pane close $PaneId
-    exit $LASTEXITCODE
+    Close-PaneGracefully $PaneId
+    exit 0
 } elseif ($Decision -like 'REPLACE *') {
     # Dead pane (stale heartbeat): close the corpse, then dock a fresh one.
     $PaneId = $Decision.Substring(8)
@@ -129,4 +196,7 @@ if ($Decision -like 'FOCUS *') {
     Open-Pane
 } else {
     Open-Pane
+}
+} finally {
+    Remove-Item -LiteralPath $LockDir -Force -ErrorAction SilentlyContinue
 }

--- a/plugins/herdr-sidebar/scripts/open-git.sh
+++ b/plugins/herdr-sidebar/scripts/open-git.sh
@@ -116,6 +116,26 @@ if [ -n "$panes" ]; then
   decision="$(printf '%s' "$panes" | "$bin" --launch-decision git 2>/dev/null || echo OPEN)"
 fi
 
+graceful_close() {
+  local pane_id=$1 listed present acknowledged=""
+  "$herdr_bin" pane send-keys "$pane_id" ctrl+q >/dev/null 2>&1 || true
+  for _ in $(seq 1 20); do
+    sleep 0.1
+    if listed="$("$herdr_bin" pane list 2>/dev/null)" &&
+      present="$(printf '%s' "$listed" | "$bin" --pane-has-token "$pane_id" 2>/dev/null)"
+    then
+      if [ "$present" != "yes" ]; then acknowledged=1; break; fi
+    fi
+  done
+  if [ -n "$acknowledged" ]; then
+    "$herdr_bin" pane close "$pane_id" >/dev/null 2>&1 || true
+  else
+    "$herdr_bin" notification show "Sidebar close cancelled" \
+      --body "The pane did not acknowledge a safe shutdown; try again shortly." \
+      --position bottom-right --sound none >/dev/null 2>&1 || true
+  fi
+}
+
 case "$decision" in
   "FOCUS "*)
     pid="${decision#FOCUS }"
@@ -124,7 +144,7 @@ case "$decision" in
     ;;
   "CLOSE "*)
     pid="${decision#CLOSE }"
-    "$herdr_bin" pane close "$pid"
+    graceful_close "$pid"
     ;;
   "REPLACE "*)
     # Dead pane (stale heartbeat): close the corpse, then dock a fresh one.

--- a/plugins/herdr-sidebar/scripts/open-git.sh
+++ b/plugins/herdr-sidebar/scripts/open-git.sh
@@ -90,16 +90,25 @@ open_pane() {
   # the explorer/last-active decision, so with the unified sidebar off this
   # launcher opened an Explorer pane labeled "Source Control" (issue #14).
   # The Windows launcher (open-git.ps1) always passed the pin.
+  focus_open="$("$bin" --focus-on-open 2>/dev/null || echo on)"
   if [ "$needs_swap" = "true" ]; then
     "$herdr_bin" pane swap --source-pane "$np" --target-pane "$target" >/dev/null 2>&1 || true
+    if [ "$focus_open" != "on" ] && [ "$target" = "$fid" ]; then
+      # "Focus on open: off" (⚙ Settings): the panel docks in the
+      # background, but the swap drags focus onto its slot (focus follows
+      # the slot). Hand it back right away, the ensure hook's move.
+      "$herdr_bin" pane focus --direction right --pane "$np" >/dev/null 2>&1 || true
+    fi
   fi
   "$herdr_bin" pane run "$np" "herdr-sidebar --view git"
   "$herdr_bin" pane rename "$np" "Source Control" >/dev/null 2>&1 || true
   # Give the TUI time to stamp its identity token before hooks re-check.
   sleep 3
-  # herdr has no focus-by-id; a zoom on/off cycle focuses deterministically.
-  "$herdr_bin" pane zoom "$np" --on >/dev/null 2>&1 || true
-  "$herdr_bin" pane zoom "$np" --off
+  if [ "$focus_open" = "on" ]; then
+    # herdr has no focus-by-id; a zoom on/off cycle focuses deterministically.
+    "$herdr_bin" pane zoom "$np" --on >/dev/null 2>&1 || true
+    "$herdr_bin" pane zoom "$np" --off
+  fi
 }
 
 decision="OPEN"

--- a/plugins/herdr-sidebar/scripts/open-sidebar.sh
+++ b/plugins/herdr-sidebar/scripts/open-sidebar.sh
@@ -118,6 +118,26 @@ fi
 snooze_dir="${TMPDIR:-/tmp}/herdr-sidebar-snooze"
 tab="$(printf '%s' "$panes" | "$bin" --focused-tab 2>/dev/null || true)"
 
+graceful_close() {
+  local pane_id=$1 listed present acknowledged=""
+  "$herdr_bin" pane send-keys "$pane_id" ctrl+q >/dev/null 2>&1 || true
+  for _ in $(seq 1 20); do
+    sleep 0.1
+    if listed="$("$herdr_bin" pane list 2>/dev/null)" &&
+      present="$(printf '%s' "$listed" | "$bin" --pane-has-token "$pane_id" 2>/dev/null)"
+    then
+      if [ "$present" != "yes" ]; then acknowledged=1; break; fi
+    fi
+  done
+  if [ -n "$acknowledged" ]; then
+    "$herdr_bin" pane close "$pane_id" >/dev/null 2>&1 || true
+  else
+    "$herdr_bin" notification show "Sidebar close cancelled" \
+      --body "The pane did not acknowledge a safe shutdown; try again shortly." \
+      --position bottom-right --sound none >/dev/null 2>&1 || true
+  fi
+}
+
 case "$decision" in
   "FOCUS "*)
     pid="${decision#FOCUS }"
@@ -130,7 +150,7 @@ case "$decision" in
       mkdir -p "$snooze_dir" 2>/dev/null
       : > "$snooze_dir/${tab//:/_}"
     fi
-    "$herdr_bin" pane close "$pid"
+    graceful_close "$pid"
     ;;
   "REPLACE "*)
     # Dead pane (stale heartbeat): close the corpse, then dock a fresh one.

--- a/plugins/herdr-sidebar/scripts/open-sidebar.sh
+++ b/plugins/herdr-sidebar/scripts/open-sidebar.sh
@@ -87,16 +87,25 @@ open_pane() {
 
   # Left docking swaps into the narrow left slot; right docking is already
   # in place. PATH makes the same bare launch work in any configured shell.
+  focus_open="$("$bin" --focus-on-open 2>/dev/null || echo on)"
   if [ "$needs_swap" = "true" ]; then
     "$herdr_bin" pane swap --source-pane "$np" --target-pane "$target" >/dev/null 2>&1 || true
+    if [ "$focus_open" != "on" ] && [ "$target" = "$fid" ]; then
+      # "Focus on open: off" (⚙ Settings): the sidebar docks in the
+      # background, but the swap drags focus onto the explorer slot (focus
+      # follows the slot). Hand it back right away, the ensure hook's move.
+      "$herdr_bin" pane focus --direction right --pane "$np" >/dev/null 2>&1 || true
+    fi
   fi
   "$herdr_bin" pane run "$np" "herdr-sidebar"
   "$herdr_bin" pane rename "$np" Explorer >/dev/null 2>&1 || true
   # Give the TUI time to stamp its identity token before hooks re-check.
   sleep 3
-  # herdr has no focus-by-id; a zoom on/off cycle focuses deterministically.
-  "$herdr_bin" pane zoom "$np" --on >/dev/null 2>&1 || true
-  "$herdr_bin" pane zoom "$np" --off
+  if [ "$focus_open" = "on" ]; then
+    # herdr has no focus-by-id; a zoom on/off cycle focuses deterministically.
+    "$herdr_bin" pane zoom "$np" --on >/dev/null 2>&1 || true
+    "$herdr_bin" pane zoom "$np" --off
+  fi
 }
 
 decision="OPEN"

--- a/plugins/herdr-sidebar/scripts/test-fetch-or-build.ps1
+++ b/plugins/herdr-sidebar/scripts/test-fetch-or-build.ps1
@@ -1,0 +1,46 @@
+$ErrorActionPreference = 'Stop'
+$Root = Join-Path ([IO.Path]::GetTempPath()) ("herdr-sidebar-test-" + [Guid]::NewGuid().ToString('N'))
+$Fixture = Join-Path $Root 'fixture'
+$Out = Join-Path $Root 'out'
+New-Item -ItemType Directory -Path $Fixture -Force | Out-Null
+try {
+    $Version = (Select-String -Path Cargo.toml -Pattern '^version\s*=\s*"([^"]+)"' | Select-Object -First 1).Matches[0].Groups[1].Value
+    $Triple = 'x86_64-pc-windows-msvc'
+    $Assets = @("herdr-sidebar-$Triple.exe", "herdr-sidebar-ensure-$Triple.exe")
+    foreach ($Asset in $Assets) {
+        [IO.File]::WriteAllText((Join-Path $Fixture $Asset), "verified-prebuilt-$Version-$Asset", (New-Object Text.UTF8Encoding($false)))
+    }
+    $Lines = foreach ($Asset in $Assets) {
+        "{0}  {1}" -f (Get-FileHash -LiteralPath (Join-Path $Fixture $Asset) -Algorithm SHA256).Hash.ToLowerInvariant(), $Asset
+    }
+    [IO.File]::WriteAllLines((Join-Path $Fixture 'SHA256SUMS'), $Lines, (New-Object Text.UTF8Encoding($false)))
+
+    $env:HS_FETCH_DIR = $Fixture
+    $env:HS_TEST_MODE = '1'
+    $env:HS_OUT_DIR = $Out
+    $env:HS_CARGO_TOML = (Resolve-Path Cargo.toml).Path
+    $env:HS_ARCH = 'AMD64'
+    & powershell -NoProfile -ExecutionPolicy Bypass -File scripts/fetch-or-build.ps1
+    if ($LASTEXITCODE -ne 0) { throw 'prebuilt install test failed' }
+    if ((Get-FileHash (Join-Path $Out 'herdr-sidebar.exe')).Hash -ne (Get-FileHash (Join-Path $Fixture $Assets[0])).Hash) { throw 'main binary mismatch' }
+    if ((Get-FileHash (Join-Path $Out 'herdr-sidebar-ensure.exe')).Hash -ne (Get-FileHash (Join-Path $Fixture $Assets[1])).Hash) { throw 'ensure binary mismatch' }
+
+    Remove-Item -LiteralPath (Join-Path $Fixture $Assets[1]) -Force
+    $Marker = Join-Path $Root 'fallback.txt'
+    $Stub = Join-Path $Root 'cargo.cmd'
+    [IO.File]::WriteAllText($Stub, "@echo off`r`necho %* > `"$Marker`"`r`n", (New-Object Text.ASCIIEncoding))
+    $env:HS_CARGO = $Stub
+    & powershell -NoProfile -ExecutionPolicy Bypass -File scripts/fetch-or-build.ps1
+    if ($LASTEXITCODE -ne 0) { throw 'source fallback test failed' }
+    if ((Get-Content -LiteralPath $Marker -Raw).Trim() -ne 'build --release') { throw 'cargo fallback was not invoked' }
+
+    [IO.File]::WriteAllText((Join-Path $Fixture $Assets[1]), "verified-prebuilt-$Version-$($Assets[1])", (New-Object Text.UTF8Encoding($false)))
+    Add-Content -LiteralPath (Join-Path $Fixture $Assets[0]) -Value 'tampered'
+    Remove-Item -LiteralPath $Marker -Force
+    & powershell -NoProfile -ExecutionPolicy Bypass -File scripts/fetch-or-build.ps1
+    if ($LASTEXITCODE -ne 0) { throw 'checksum fallback test failed' }
+    if ((Get-Content -LiteralPath $Marker -Raw).Trim() -ne 'build --release') { throw 'checksum mismatch did not invoke cargo fallback' }
+} finally {
+    Remove-Item Env:HS_FETCH_DIR,Env:HS_TEST_MODE,Env:HS_OUT_DIR,Env:HS_CARGO_TOML,Env:HS_ARCH,Env:HS_CARGO -ErrorAction SilentlyContinue
+    Remove-Item -LiteralPath $Root -Recurse -Force -ErrorAction SilentlyContinue
+}

--- a/plugins/herdr-sidebar/scripts/test-fetch-or-build.sh
+++ b/plugins/herdr-sidebar/scripts/test-fetch-or-build.sh
@@ -1,0 +1,46 @@
+#!/bin/sh
+set -eu
+
+root=$(mktemp -d)
+trap 'rm -rf "$root"' EXIT
+fixture="$root/fixture"
+out="$root/out/herdr-sidebar"
+mkdir -p "$fixture"
+version=$(grep -E '^version *= *"' Cargo.toml | head -n1 | sed -E 's/^version *= *"([^"]+)".*/\1/')
+test_os=${HS_UNAME_S:-$(uname -s)}
+test_arch=${HS_UNAME_M:-$(uname -m)}
+case "$test_os/$test_arch" in
+  Linux/x86_64) triple=x86_64-unknown-linux-musl ;;
+  Darwin/arm64) triple=aarch64-apple-darwin ;;
+  Darwin/x86_64) triple=x86_64-apple-darwin ;;
+  *) echo "unsupported test runner" >&2; exit 1 ;;
+esac
+asset="herdr-sidebar-$triple"
+printf 'verified-prebuilt-%s\n' "$version" > "$fixture/$asset"
+if command -v sha256sum >/dev/null 2>&1; then
+  (cd "$fixture" && sha256sum "$asset" > SHA256SUMS)
+else
+  (cd "$fixture" && shasum -a 256 "$asset" > SHA256SUMS)
+fi
+
+HS_TEST_MODE=1 HS_FETCH_DIR="$fixture" HS_OUT="$out" HS_CARGO_TOML="$PWD/Cargo.toml" \
+  sh scripts/fetch-or-build.sh
+cmp "$fixture/$asset" "$out"
+
+rm -f "$fixture/$asset"
+marker="$root/fallback"
+stub="$root/cargo"
+cat > "$stub" <<'EOF'
+#!/bin/sh
+printf '%s\n' "$*" > "$HS_FALLBACK_MARKER"
+EOF
+chmod +x "$stub"
+HS_TEST_MODE=1 HS_FETCH_DIR="$fixture" HS_OUT="$out" HS_CARGO_TOML="$PWD/Cargo.toml" \
+  HS_CARGO="$stub" HS_FALLBACK_MARKER="$marker" sh scripts/fetch-or-build.sh
+grep -Fx 'build --release' "$marker"
+
+printf 'tampered\n' > "$fixture/$asset"
+rm -f "$marker"
+HS_TEST_MODE=1 HS_FETCH_DIR="$fixture" HS_OUT="$out" HS_CARGO_TOML="$PWD/Cargo.toml" \
+  HS_CARGO="$stub" HS_FALLBACK_MARKER="$marker" sh scripts/fetch-or-build.sh
+grep -Fx 'build --release' "$marker"

--- a/plugins/herdr-sidebar/src/ensure.rs
+++ b/plugins/herdr-sidebar/src/ensure.rs
@@ -53,10 +53,11 @@ use crate::snooze;
 /// focus, and respecting a tab the user toggled closed. Toggle mode (the
 /// action): open-or-focus-or-close, like VS Code's explorer shortcut.
 pub fn run(toggle: bool) -> std::io::Result<()> {
+    let state = crate::state::load_state();
     // Auto-open off (⚙ Settings): hooks leave closed tabs alone; the user's
     // explicit toggle still works. The unix hook script makes the same check
     // via `herdr-sidebar --auto-open`.
-    if !toggle && !crate::state::load_state().auto_open {
+    if !toggle && !state.auto_open {
         return Ok(());
     }
     let event_json = std::env::var("HERDR_PLUGIN_EVENT_JSON").unwrap_or_default();
@@ -82,7 +83,15 @@ pub fn run(toggle: bool) -> std::io::Result<()> {
     match launch::launch_decision_in(&panes, now, &scope).split_once(' ') {
         Some(("FOCUS", id)) => {
             if toggle {
-                focus(id)?;
+                if state.strict_toggle {
+                    // Strict toggle (⚙ Settings): one press opens, the next
+                    // press closes, wherever focus is. The unix launchers get
+                    // the same mapping from the --launch-decision CLI mode.
+                    ipc::call_text("pane.close", serde_json::json!({ "pane_id": id }))?;
+                    snooze::set(&snooze_dir, &tab);
+                } else {
+                    focus(id)?;
+                }
             }
         }
         Some(("CLOSE", id)) => {
@@ -99,12 +108,14 @@ pub fn run(toggle: bool) -> std::io::Result<()> {
             // id. Re-plan from a fresh snapshot rather than splitting a pane
             // that no longer exists.
             panes = ipc::call_text("pane.list", serde_json::json!({}))?;
-            open(&panes, toggle, &scope)?;
+            open(&panes, toggle && state.focus_on_open, &scope)?;
         }
         _ => {
             if toggle {
                 snooze::clear(&snooze_dir, &tab);
-                open(&panes, true, &scope)?;
+                // "Focus on open: off" (⚙ Settings) docks in the background:
+                // open()'s quiet path already hands focus back after the swap.
+                open(&panes, state.focus_on_open, &scope)?;
             } else if !snooze::is_set(&snooze_dir, &tab) {
                 open(&panes, false, &scope)?;
             }

--- a/plugins/herdr-sidebar/src/ensure.rs
+++ b/plugins/herdr-sidebar/src/ensure.rs
@@ -87,7 +87,7 @@ pub fn run(toggle: bool) -> std::io::Result<()> {
                     // Strict toggle (⚙ Settings): one press opens, the next
                     // press closes, wherever focus is. The unix launchers get
                     // the same mapping from the --launch-decision CLI mode.
-                    ipc::call_text("pane.close", serde_json::json!({ "pane_id": id }))?;
+                    graceful_close(id);
                     snooze::set(&snooze_dir, &tab);
                 } else {
                     focus(id)?;
@@ -96,7 +96,7 @@ pub fn run(toggle: bool) -> std::io::Result<()> {
         }
         Some(("CLOSE", id)) => {
             if toggle {
-                ipc::call_text("pane.close", serde_json::json!({ "pane_id": id }))?;
+                graceful_close(id);
                 snooze::set(&snooze_dir, &tab);
             }
         }
@@ -122,6 +122,36 @@ pub fn run(toggle: bool) -> std::io::Result<()> {
         }
     }
     Ok(())
+}
+
+fn graceful_close(pane_id: &str) {
+    let _ = ipc::call_text(
+        "pane.send_input",
+        serde_json::json!({ "pane_id": pane_id, "text": "", "keys": ["ctrl+q"] }),
+    );
+    let mut acknowledged = false;
+    for _ in 0..20 {
+        std::thread::sleep(std::time::Duration::from_millis(100));
+        if let Ok(json) = ipc::call_text("pane.list", serde_json::json!({}))
+            && !launch::pane_has_token(&json, pane_id)
+        {
+            acknowledged = true;
+            break;
+        }
+    }
+    if acknowledged {
+        let _ = ipc::call_text("pane.close", serde_json::json!({ "pane_id": pane_id }));
+    } else {
+        let _ = ipc::call_text(
+            "notification.show",
+            serde_json::json!({
+                "title": "Sidebar close cancelled",
+                "body": "The pane did not acknowledge a safe shutdown; try again shortly.",
+                "position": "bottom-right",
+                "sound": "none",
+            }),
+        );
+    }
 }
 
 fn snooze_tab_for_scope(panes_json: &str, scope: &str) -> String {

--- a/plugins/herdr-sidebar/src/explorer_app.rs
+++ b/plugins/herdr-sidebar/src/explorer_app.rs
@@ -4,7 +4,9 @@
 
 use std::path::{Path, PathBuf};
 
-use crossterm::event::{KeyCode, KeyEvent, KeyEventKind, MouseButton, MouseEvent, MouseEventKind};
+use crossterm::event::{
+    KeyCode, KeyEvent, KeyEventKind, KeyModifiers, MouseButton, MouseEvent, MouseEventKind,
+};
 use ratatui::Frame;
 use ratatui::layout::{Alignment, Constraint, Layout, Rect};
 use ratatui::style::{Color, Modifier, Style, Stylize};
@@ -20,8 +22,9 @@ use herdr_sidebar::state::{self as sidebar, View};
 use herdr_sidebar::tree::{Row, Tree};
 use herdr_sidebar::ui::{
     TitleAction, activity_icons, draw_scrollbar, gear_icon, hits, hits_collapse_button, input_tail,
-    sibling_panes_of, status_color, title_action_spans, title_actions_visible, title_actions_width,
-    truncate_to, wrap_footer_message, wrap_hints,
+    hover_style, keep_visible_scroll, palette, selection_style, set_color_theme,
+    sibling_panes_of, status_color, title_action_spans, title_actions_visible,
+    title_actions_width, truncate_to, wrap_footer_message, wrap_hints,
 };
 
 use herdr_sidebar::state::Exit;
@@ -171,6 +174,7 @@ enum Overlay {
     Settings {
         selected: usize,
         rect: Rect,
+        scroll: usize,
     },
 }
 
@@ -181,6 +185,7 @@ enum Setting {
     DockRight,
     SidebarWidth,
     IconTheme,
+    ColorTheme,
     AutoOpen,
     StrictToggle,
     FocusOnOpen,
@@ -313,6 +318,7 @@ impl App {
         // The other view ships in this same binary — always available.
         let other_exe = std::env::current_exe().ok();
         let sidebar_state = sidebar::load_state();
+        set_color_theme(sidebar_state.color_theme);
         let repos = if sidebar_state.git_deco {
             Git::discover_all(&tree.root_path())
         } else {
@@ -379,6 +385,12 @@ impl App {
     fn sync_shared_settings(&mut self) {
         let shared = sidebar::load_state();
         self.sidebar_state.dock_right = shared.dock_right;
+        self.sidebar_state.strict_toggle = shared.strict_toggle;
+        self.sidebar_state.focus_on_open = shared.focus_on_open;
+        if shared.color_theme != self.sidebar_state.color_theme {
+            self.sidebar_state.color_theme = shared.color_theme;
+            set_color_theme(shared.color_theme);
+        }
         if shared.sidebar_width != self.sidebar_state.sidebar_width {
             self.sidebar_state.sidebar_width = shared.sidebar_width;
             if let Some(ctl) = &self.pane_ctl {
@@ -538,6 +550,12 @@ impl App {
         ctl.report_tokens(MY_VIEW, self.merged());
     }
 
+    pub fn clear_identity(&self) {
+        if let Some(ctl) = &self.pane_ctl {
+            herdr_sidebar::ipc::clear_identity(&ctl.pane_id);
+        }
+    }
+
     /// Open a file in the preview pane BESIDE the sidebar (the tree stays
     /// visible): the shared viewer client reuses the tab's viewer pane or
     /// spawns one next to us.
@@ -674,6 +692,12 @@ impl App {
     pub fn on_key(&mut self, key: KeyEvent) -> Option<Exit> {
         if key.kind != KeyEventKind::Press {
             return None;
+        }
+        if key.code == KeyCode::Char('q')
+            && key.modifiers.contains(KeyModifiers::CONTROL)
+            && !key.modifiers.contains(KeyModifiers::ALT)
+        {
+            return Some(Exit::Quit);
         }
         self.notice = None;
         if self.overlay.is_some() {
@@ -998,15 +1022,21 @@ impl App {
         }
         let row_count = self.settings_rows().len();
         let cmd = match self.overlay.as_mut() {
-            Some(Overlay::Settings { selected, rect }) => {
+            Some(Overlay::Settings {
+                selected,
+                rect,
+                scroll,
+            }) => {
                 // Rows start just inside the top border (the title renders ON
                 // the border, not on its own line).
                 let row_at = |row: u16, col: u16| -> Option<usize> {
+                    let index = usize::from(row.saturating_sub(rect.y + 1)) + *scroll;
                     (col > rect.x
                         && col < rect.x + rect.width.saturating_sub(1)
                         && row > rect.y
-                        && row < rect.y + 1 + row_count as u16)
-                        .then(|| usize::from(row - rect.y - 1))
+                        && row < rect.y + rect.height.saturating_sub(1)
+                        && index < row_count)
+                        .then_some(index)
                 };
                 match mouse.kind {
                     MouseEventKind::Moved => {
@@ -1093,6 +1123,7 @@ impl App {
         self.overlay = Some(Overlay::Settings {
             selected: 0,
             rect: Rect::default(),
+            scroll: 0,
         });
     }
 
@@ -1130,6 +1161,12 @@ impl App {
                     IconTheme::Emoji => "emoji",
                 }
                 .to_string(),
+                true,
+            ),
+            (
+                Setting::ColorTheme,
+                "Color theme",
+                self.sidebar_state.color_theme.label().to_string(),
                 true,
             ),
             (
@@ -1233,6 +1270,12 @@ impl App {
             }
             Setting::SidebarWidth => self.adjust_sidebar_width(true),
             Setting::IconTheme => self.set_theme(self.theme.toggled()),
+            Setting::ColorTheme => {
+                self.sidebar_state = sidebar::update_state(|state| {
+                    state.color_theme = state.color_theme.other();
+                });
+                set_color_theme(self.sidebar_state.color_theme);
+            }
             Setting::HiddenFiles => {
                 self.tree.show_hidden = !self.tree.show_hidden;
                 self.rebuild();
@@ -1297,7 +1340,12 @@ impl App {
         let width = desired_width.min(area.width);
         // The hotkey reference lives here now; the footer chips are opt-in.
         let hint_lines = wrap_hints(&self.hints(), width.saturating_sub(2), 0);
-        let Some(Overlay::Settings { selected, rect }) = self.overlay.as_mut() else {
+        let Some(Overlay::Settings {
+            selected,
+            rect,
+            scroll,
+        }) = self.overlay.as_mut()
+        else {
             return;
         };
         let height = (rows.len() as u16 + 5 + hint_lines.len() as u16).min(area.height);
@@ -1308,6 +1356,9 @@ impl App {
             height,
         );
         *rect = popup;
+        let inner_height = usize::from(height.saturating_sub(2));
+        let content_height = rows.len() + 3 + hint_lines.len();
+        *scroll = keep_visible_scroll(*selected, inner_height, content_height);
 
         let inner_w = usize::from(width.saturating_sub(2));
         let mut lines: Vec<Line> = Vec::new();
@@ -1317,9 +1368,7 @@ impl App {
             let style = if !enabled {
                 Style::default().dim()
             } else if i == *selected {
-                Style::default()
-                    .bg(Color::DarkGray)
-                    .add_modifier(Modifier::BOLD)
+                selection_style(true)
             } else {
                 Style::default()
             };
@@ -1335,7 +1384,7 @@ impl App {
 
         frame.render_widget(Clear, popup);
         frame.render_widget(
-            Paragraph::new(lines).block(
+            Paragraph::new(lines).scroll((*scroll as u16, 0)).block(
                 ratatui::widgets::Block::bordered()
                     .title(" Settings ")
                     .border_style(Style::default().dim()),
@@ -1818,7 +1867,7 @@ impl App {
         let [_, footer_button] =
             Layout::horizontal([Constraint::Min(0), Constraint::Length(3)]).areas(last_line);
         frame.render_widget(
-            Paragraph::new("«".bold().fg(Color::LightBlue)).alignment(Alignment::Center),
+            Paragraph::new("«".bold().fg(palette().header_accent)).alignment(Alignment::Center),
             footer_button,
         );
         let footer_lines: Vec<Line> = if let Some((msg, color)) = self.footer_message() {
@@ -1914,7 +1963,10 @@ impl App {
         // The name yields to the buttons and gear in narrow panes.
         let avail = usize::from(area.width.saturating_sub(gear_w + actions_w));
         let root_label = truncate_to(format!(" {}", self.tree.root_name().to_uppercase()), avail);
-        let name = Span::styled(root_label, Style::default().bold().fg(Color::LightBlue));
+        let name = Span::styled(
+            root_label,
+            Style::default().bold().fg(palette().header_accent),
+        );
         let pad = usize::from(area.width)
             .saturating_sub(name.width() + usize::from(actions_w) + usize::from(gear_w));
         let mut spans = vec![name, Span::raw(" ".repeat(pad))];
@@ -1985,14 +2037,17 @@ impl App {
     /// delete confirm. Shared by footer_height and draw so they agree.
     fn footer_message(&self) -> Option<(String, Color)> {
         if let Some(notice) = &self.notice {
-            return Some((notice.clone(), Color::Yellow));
+            return Some((notice.clone(), palette().modified));
         }
         if let Some(Overlay::ConfirmDelete { path, .. }) = &self.overlay {
             let name = path
                 .file_name()
                 .map(|n| n.to_string_lossy().into_owned())
                 .unwrap_or_default();
-            return Some((format!("Delete '{name}' permanently? (y/N)"), Color::Red));
+            return Some((
+                format!("Delete '{name}' permanently? (y/N)"),
+                palette().deleted,
+            ));
         }
         None
     }
@@ -2009,9 +2064,7 @@ impl App {
         let (exp_icon, git_icon) = activity_icons(self.theme);
         let active = |on: bool| {
             if on {
-                Style::default()
-                    .bg(Color::DarkGray)
-                    .add_modifier(Modifier::BOLD)
+                selection_style(true)
             } else {
                 Style::default().dim()
             }
@@ -2049,7 +2102,7 @@ impl App {
         let chip_w = chip_end.saturating_sub(chip_start);
         let cap = |glyph: &str| {
             Paragraph::new(glyph.repeat(usize::from(chip_w)))
-                .style(Style::default().fg(Color::DarkGray))
+                .style(Style::default().fg(palette().selection_bg))
         };
         frame.render_widget(cap("▄"), Rect::new(chip_start, outer_top, chip_w, 1));
         frame.render_widget(cap("▀"), Rect::new(chip_start, outer_bottom, chip_w, 1));
@@ -2110,9 +2163,7 @@ impl App {
                     let line = Line::raw(format!(" {label}"));
                     if i == *selected {
                         ListItem::new(line).style(
-                            Style::default()
-                                .bg(Color::DarkGray)
-                                .add_modifier(Modifier::BOLD),
+                            selection_style(true),
                         )
                     } else {
                         ListItem::new(line)
@@ -2191,14 +2242,10 @@ fn row_item(
 /// content so a git decoration (foreground-only) can never collide with it.
 fn row_bg(hovered: bool, selected: bool) -> Option<Style> {
     if selected {
-        Some(
-            Style::default()
-                .bg(Color::DarkGray)
-                .add_modifier(Modifier::BOLD),
-        )
+        Some(selection_style(true))
     } else if hovered {
         // Subtler than the selection bg — hover is a hint, not a choice.
-        Some(Style::default().bg(Color::Rgb(48, 52, 60)))
+        Some(hover_style())
     } else {
         None
     }
@@ -2429,11 +2476,11 @@ mod tests {
         // name, or a selected changed row would be unreadable.
         assert_eq!(
             row_bg(false, true).and_then(|s| s.bg),
-            Some(Color::DarkGray)
+            Some(palette().selection_bg)
         );
         assert_eq!(
             row_bg(true, false).and_then(|s| s.bg),
-            Some(Color::Rgb(48, 52, 60))
+            Some(palette().hover_bg)
         );
         assert_eq!(row_bg(false, false), None);
         // The decoration itself only ever sets a foreground.

--- a/plugins/herdr-sidebar/src/explorer_app.rs
+++ b/plugins/herdr-sidebar/src/explorer_app.rs
@@ -182,6 +182,8 @@ enum Setting {
     SidebarWidth,
     IconTheme,
     AutoOpen,
+    StrictToggle,
+    FocusOnOpen,
     FollowCwd,
     HiddenFiles,
     Hotkeys,
@@ -1164,6 +1166,28 @@ impl App {
                 true,
             ),
             (
+                Setting::StrictToggle,
+                "Strict toggle",
+                if self.sidebar_state.strict_toggle {
+                    "on"
+                } else {
+                    "off"
+                }
+                .to_string(),
+                true,
+            ),
+            (
+                Setting::FocusOnOpen,
+                "Focus on open",
+                if self.sidebar_state.focus_on_open {
+                    "on"
+                } else {
+                    "off"
+                }
+                .to_string(),
+                true,
+            ),
+            (
                 Setting::FollowCwd,
                 "Follow pane folder",
                 sidebar::follow_cwd_setting_value(self.sidebar_state.follow_cwd),
@@ -1220,6 +1244,14 @@ impl App {
             Setting::AutoOpen => {
                 self.sidebar_state =
                     sidebar::update_state(|state| state.auto_open = !state.auto_open);
+            }
+            Setting::StrictToggle => {
+                self.sidebar_state =
+                    sidebar::update_state(|state| state.strict_toggle = !state.strict_toggle);
+            }
+            Setting::FocusOnOpen => {
+                self.sidebar_state =
+                    sidebar::update_state(|state| state.focus_on_open = !state.focus_on_open);
             }
             Setting::FollowCwd => {
                 self.sidebar_state =

--- a/plugins/herdr-sidebar/src/fontsetup.rs
+++ b/plugins/herdr-sidebar/src/fontsetup.rs
@@ -21,7 +21,7 @@ use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, Clear, Paragraph};
 
 use crate::state::{self, View};
-use crate::ui::{KEYCAP_BG, KEYCAP_FG, wrap_footer_message};
+use crate::ui::{palette, wrap_footer_message};
 use crate::{actions, icons, ipc};
 
 const FONT_NAME: &str = "JetBrainsMono Nerd Font";
@@ -251,7 +251,11 @@ fn option_lines(key: &'static str, label: &str, width: u16) -> Vec<Line<'static>
         .enumerate()
         .map(|(i, l)| {
             let lead: Span<'static> = if i == 0 {
-                Span::styled(cap.clone(), Style::default().bg(KEYCAP_BG).fg(KEYCAP_FG))
+                let colors = palette();
+                Span::styled(
+                    cap.clone(),
+                    Style::default().bg(colors.keycap_bg).fg(colors.keycap_fg),
+                )
             } else {
                 Span::raw(" ".repeat(usize::from(cap_cols) - 1))
             };

--- a/plugins/herdr-sidebar/src/ipc.rs
+++ b/plugins/herdr-sidebar/src/ipc.rs
@@ -86,6 +86,25 @@ pub fn report_identity(pane_id: &str, my: crate::state::View, merged: bool) {
     );
 }
 
+/// Clear both sidebar identity tokens after the event loop has finished its
+/// final persistence. Launchers poll this acknowledgement before removing the
+/// now-idle shell pane.
+pub fn clear_identity(pane_id: &str) {
+    for view in [
+        crate::state::View::Explorer,
+        crate::state::View::SourceControl,
+    ] {
+        let _ = call_text(
+            "pane.report_metadata",
+            serde_json::json!({
+                "pane_id": pane_id,
+                "source": view.plugin_id(),
+                "tokens": { view.plugin_id(): serde_json::Value::Null },
+            }),
+        );
+    }
+}
+
 // Windows' named-pipe `File` handle has no `set_read_timeout` via std (no
 // overlapped I/O in this fix's scope), so it's bounded with a background
 // thread instead. unix sockets support native read/write timeouts, which

--- a/plugins/herdr-sidebar/src/launch.rs
+++ b/plugins/herdr-sidebar/src/launch.rs
@@ -291,6 +291,17 @@ pub fn launch_decision_in(pane_list_json: &str, now: u64, scope: &str) -> String
     }
 }
 
+/// Strict-toggle mapping (⚙ Settings): a `FOCUS` decision becomes `CLOSE`,
+/// so one toggle press opens and the next press closes, wherever focus is.
+/// Every other decision passes through untouched; kept pure so both the CLI
+/// mode and the Windows ensure sidecar share one tested mapping.
+pub fn focus_as_close(decision: &str) -> String {
+    match decision.split_once(' ') {
+        Some(("FOCUS", id)) => format!("CLOSE {id}"),
+        _ => decision.to_string(),
+    }
+}
+
 /// Source-control identity for the separated Source Control pane.
 pub const SC_PANE_LABEL: &str = "Source Control";
 pub const SC_METADATA_SOURCE: &str = "herdr-sidebar-git";
@@ -831,6 +842,17 @@ fn strip_verbatim(path: &str) -> &str {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Strict toggle rewrites only the FOCUS decision; OPEN, CLOSE, and
+    /// REPLACE (and garbage) must reach the launchers untouched.
+    #[test]
+    fn strict_toggle_maps_focus_to_close_and_nothing_else() {
+        assert_eq!(focus_as_close("FOCUS w4:p2"), "CLOSE w4:p2");
+        assert_eq!(focus_as_close("OPEN"), "OPEN");
+        assert_eq!(focus_as_close("CLOSE w4:p2"), "CLOSE w4:p2");
+        assert_eq!(focus_as_close("REPLACE w4:p2"), "REPLACE w4:p2");
+        assert_eq!(focus_as_close(""), "");
+    }
 
     /// The decision and the dock must reason about the SAME tab. Scoping only
     /// the spawn cwd would let the decision see a focused tab with no sidebar,

--- a/plugins/herdr-sidebar/src/main.rs
+++ b/plugins/herdr-sidebar/src/main.rs
@@ -33,11 +33,18 @@ fn main() -> std::io::Result<()> {
             // answers for one tab while the dock lands in another.
             let now = state::unix_now();
             let scope = std::env::args().nth(3).unwrap_or_default();
-            let out = if std::env::args().nth(2).as_deref() == Some("git") {
+            let mut out = if std::env::args().nth(2).as_deref() == Some("git") {
                 launch::launch_decision_git(&read_stdin()?, now)
             } else {
                 launch::launch_decision_in(&read_stdin()?, now, &scope)
             };
+            // Strict toggle (⚙ Settings): report an open-but-unfocused pane
+            // as CLOSE so the toggle launchers close it instead of focusing
+            // it first. Safe for the ensure hook, which ignores FOCUS and
+            // CLOSE alike (it only acts on OPEN and REPLACE).
+            if state::load_state().strict_toggle {
+                out = launch::focus_as_close(&out);
+            }
             println!("{out}");
             return Ok(());
         }
@@ -83,6 +90,13 @@ fn main() -> std::io::Result<()> {
             println!("{}", if state::load_state().auto_open { "on" } else { "off" });
             return Ok(());
         }
+        Some("--focus-on-open") => {
+            // For the unix toggle launchers: skip the open-then-focus zoom
+            // cycle when the user turned "Focus on open" off in ⚙ Settings,
+            // so the sidebar docks in the background.
+            println!("{}", if state::load_state().focus_on_open { "on" } else { "off" });
+            return Ok(());
+        }
         Some("--dock-right") => {
             println!("{}", if state::load_state().dock_right { "right" } else { "left" });
             return Ok(());
@@ -104,7 +118,7 @@ fn main() -> std::io::Result<()> {
         Some(other) => {
             eprintln!("herdr-sidebar: unknown argument `{other}`");
             eprintln!(
-                "usage: herdr-sidebar [--view explorer|git|--preview [ctl]|--launch-decision [git]|--focused-pane|--pane-has-token <id>|--open-plan|--focused-tab|--auto-open|--dock-right]"
+                "usage: herdr-sidebar [--view explorer|git|--preview [ctl]|--launch-decision [git]|--focused-pane|--pane-has-token <id>|--open-plan|--focused-tab|--auto-open|--focus-on-open|--dock-right]"
             );
             std::process::exit(2);
         }

--- a/plugins/herdr-sidebar/src/main.rs
+++ b/plugins/herdr-sidebar/src/main.rs
@@ -133,6 +133,7 @@ fn main() -> std::io::Result<()> {
         None
     };
     let persisted = state::load_state();
+    herdr_sidebar::ui::set_color_theme(persisted.color_theme);
     let mut view = pinned.unwrap_or(if persisted.merged {
         persisted.active
     } else {
@@ -243,6 +244,9 @@ fn run_explorer(
                 _ => None, // resize, focus, … simply fall through to a redraw
             };
             if let Some(exit) = exit {
+                if exit == Exit::Quit {
+                    app.clear_identity();
+                }
                 return Ok(exit);
             }
         }
@@ -282,6 +286,15 @@ fn run_scm(
                 _ => None,
             };
             if let Some(exit) = exit {
+                // Switching drops this App and rebuilds it later, so it needs
+                // the same persistence gate as quitting or a draft would be
+                // lost despite the process staying alive.
+                if !app.persist_scm() {
+                    continue;
+                }
+                if exit == Exit::Quit {
+                    app.clear_identity();
+                }
                 return Ok(exit);
             }
         }

--- a/plugins/herdr-sidebar/src/scm_app.rs
+++ b/plugins/herdr-sidebar/src/scm_app.rs
@@ -28,18 +28,12 @@ use herdr_sidebar::state::Exit;
 use herdr_sidebar::state::{self as sidebar, View};
 use herdr_sidebar::suggest;
 use herdr_sidebar::ui::{
-    DELETED, TitleAction, UNTRACKED, activity_icons, branch_icon, draw_scrollbar, gear_icon, hits,
-    hits_collapse_button, sibling_panes_of, sparkle_icon, status_color, title_action_spans,
+    TitleAction, activity_icons, branch_icon, draw_scrollbar, gear_icon, hits,
+    hits_collapse_button, hover_style, keep_visible_scroll, palette, selection_style,
+    set_color_theme, sibling_panes_of, sparkle_icon, status_color, title_action_spans,
     title_actions_visible, title_actions_width, truncate_to, within, wrap_footer_message,
     wrap_hints,
 };
-
-// VS Code's dark-theme button colors; the git status colors themselves live
-// in `ui.rs` so the Explorer decorations use the very same palette.
-const BUTTON_BLUE: Color = Color::Rgb(0x00, 0x78, 0xd4);
-const BUTTON_BLUE_FOCUS: Color = Color::Rgb(0x02, 0x8a, 0xf0);
-const BADGE_BLUE: Color = Color::Rgb(0x00, 0x78, 0xd4);
-const HOVER_BG: Color = Color::Rgb(48, 52, 60);
 
 /// How many log lines the history-ish drawers fetch.
 const DRAWER_LIMIT: usize = 30;
@@ -402,6 +396,7 @@ enum Overlay {
     Settings {
         selected: usize,
         rect: Rect,
+        scroll: usize,
     },
 }
 
@@ -412,6 +407,7 @@ enum Setting {
     DockRight,
     SidebarWidth,
     IconTheme,
+    ColorTheme,
     AutoOpen,
     StrictToggle,
     FocusOnOpen,
@@ -604,6 +600,10 @@ pub struct App {
     /// Shared across rebuilds and unified-view switches so a manual folder
     /// choice keeps its precedence until a known neighbour actually moves.
     cwd_follower: std::rc::Rc<std::cell::RefCell<herdr_sidebar::launch::CwdFollower>>,
+    /// Draft roots this pane loaded or successfully persisted. An empty box
+    /// only clears one of these roots, so a stale sibling pane cannot erase a
+    /// newer draft it never observed.
+    persisted_draft_roots: std::collections::BTreeSet<String>,
 }
 
 const MY_VIEW: View = View::SourceControl;
@@ -613,7 +613,7 @@ impl App {
         cwd: PathBuf,
         cwd_follower: std::rc::Rc<std::cell::RefCell<herdr_sidebar::launch::CwdFollower>>,
     ) -> Self {
-        let repos: Vec<Repo> = Git::discover_all(&cwd).into_iter().map(Repo::new).collect();
+        let mut repos: Vec<Repo> = Git::discover_all(&cwd).into_iter().map(Repo::new).collect();
         let discover_err = if repos.is_empty() {
             Git::discover(&cwd)
                 .err()
@@ -632,6 +632,7 @@ impl App {
         // The other view ships in this same binary — always available.
         let other_exe = std::env::current_exe().ok();
         let sidebar_state = sidebar::load_state();
+        set_color_theme(sidebar_state.color_theme);
         let pane_ctl = PaneCtl::from_env();
         let last_layout_width = pane_ctl.as_ref().and_then(PaneCtl::layout_width);
 
@@ -640,6 +641,7 @@ impl App {
         // the same repo active, and the same row selected. Parallel to the
         // explorer's tree-state restore.
         let saved = sidebar::load_scm_state(&cwd);
+        let persisted_draft_roots = saved.drafts.keys().cloned().collect();
         let mut drawers: [DrawerPanel; 8] = Default::default();
         for kind in Drawer::ALL {
             drawers[kind.index()].expanded = saved.drawers.iter().any(|d| d == kind.title());
@@ -657,6 +659,13 @@ impl App {
         let history_target = saved.history_target;
         let selected_id = saved.selected;
         let saved_scroll = saved.scroll;
+        for repo in &mut repos {
+            let root = sidebar::scm_path_key(repo.git.root());
+            if let Some(message) = saved.drafts.get(&root) {
+                repo.message = message.chars().collect();
+                repo.cursor = repo.message.len();
+            }
+        }
 
         let mut app = Self {
             repos,
@@ -693,6 +702,7 @@ impl App {
             last_beat: std::time::Instant::now(),
             picking: None,
             cwd_follower,
+            persisted_draft_roots,
         };
         app.apply_identity();
         app.refresh();
@@ -740,6 +750,12 @@ impl App {
         };
         ctl.set_label(Some(label));
         ctl.report_tokens(MY_VIEW, self.merged());
+    }
+
+    pub fn clear_identity(&self) {
+        if let Some(ctl) = &self.pane_ctl {
+            herdr_sidebar::ipc::clear_identity(&ctl.pane_id);
+        }
     }
 
     /// Hide the sidebar: snooze this tab (so the quiet ensure hook doesn't
@@ -830,6 +846,12 @@ impl App {
         let shared = sidebar::load_state();
         self.sidebar_state.git_deco = shared.git_deco;
         self.sidebar_state.dock_right = shared.dock_right;
+        self.sidebar_state.strict_toggle = shared.strict_toggle;
+        self.sidebar_state.focus_on_open = shared.focus_on_open;
+        if shared.color_theme != self.sidebar_state.color_theme {
+            self.sidebar_state.color_theme = shared.color_theme;
+            set_color_theme(shared.color_theme);
+        }
         if shared.sidebar_width != self.sidebar_state.sidebar_width {
             self.sidebar_state.sidebar_width = shared.sidebar_width;
             if let Some(ctl) = &self.pane_ctl {
@@ -1086,6 +1108,12 @@ impl App {
         if key.kind != KeyEventKind::Press {
             return None;
         }
+        if key.code == KeyCode::Char('q')
+            && key.modifiers.contains(KeyModifiers::CONTROL)
+            && !key.modifiers.contains(KeyModifiers::ALT)
+        {
+            return Some(Exit::Quit);
+        }
         self.flash = None;
         if self.overlay.is_some() {
             self.overlay_key(key);
@@ -1130,11 +1158,17 @@ impl App {
             KeyCode::Right => repo.cursor = (repo.cursor + 1).min(repo.message.len()),
             KeyCode::Home => repo.cursor = 0,
             KeyCode::End => repo.cursor = repo.message.len(),
-            KeyCode::Char('u') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+            KeyCode::Char('u')
+                if key.modifiers.contains(KeyModifiers::CONTROL)
+                    && !key.modifiers.contains(KeyModifiers::ALT) =>
+            {
                 repo.message.clear();
                 repo.cursor = 0;
             }
-            KeyCode::Char(c) if !key.modifiers.contains(KeyModifiers::CONTROL) => {
+            KeyCode::Char(c)
+                if !key.modifiers.contains(KeyModifiers::CONTROL)
+                    || key.modifiers.contains(KeyModifiers::ALT) =>
+            {
                 repo.message.insert(repo.cursor, c);
                 repo.cursor += 1;
             }
@@ -1612,15 +1646,21 @@ impl App {
         }
         let row_count = self.settings_rows().len();
         let cmd = match self.overlay.as_mut() {
-            Some(Overlay::Settings { selected, rect }) => {
+            Some(Overlay::Settings {
+                selected,
+                rect,
+                scroll,
+            }) => {
                 // Rows start just inside the top border (the title renders ON
                 // the border, not on its own line).
                 let row_at = |row: u16, col: u16| -> Option<usize> {
+                    let index = usize::from(row.saturating_sub(rect.y + 1)) + *scroll;
                     (col > rect.x
                         && col < rect.x + rect.width.saturating_sub(1)
                         && row > rect.y
-                        && row < rect.y + 1 + row_count as u16)
-                        .then(|| usize::from(row - rect.y - 1))
+                        && row < rect.y + rect.height.saturating_sub(1)
+                        && index < row_count)
+                        .then_some(index)
                 };
                 match mouse.kind {
                     MouseEventKind::Moved => {
@@ -1701,6 +1741,7 @@ impl App {
         self.overlay = Some(Overlay::Settings {
             selected: 0,
             rect: Rect::default(),
+            scroll: 0,
         });
     }
 
@@ -1738,6 +1779,12 @@ impl App {
                     IconTheme::Emoji => "emoji",
                 }
                 .to_string(),
+                true,
+            ),
+            (
+                Setting::ColorTheme,
+                "Color theme",
+                self.sidebar_state.color_theme.label().to_string(),
                 true,
             ),
             (
@@ -1833,6 +1880,12 @@ impl App {
             }
             Setting::SidebarWidth => self.adjust_sidebar_width(true),
             Setting::IconTheme => self.set_theme(self.theme.toggled()),
+            Setting::ColorTheme => {
+                self.sidebar_state = sidebar::update_state(|state| {
+                    state.color_theme = state.color_theme.other();
+                });
+                set_color_theme(self.sidebar_state.color_theme);
+            }
             Setting::Hotkeys => {
                 self.sidebar_state =
                     sidebar::update_state(|state| state.show_hotkeys = !state.show_hotkeys);
@@ -1944,7 +1997,12 @@ impl App {
         let width = desired_width.min(area.width);
         // The hotkey reference lives here now; the footer chips are opt-in.
         let hint_lines = wrap_hints(&self.hints(), width.saturating_sub(2), 0);
-        let Some(Overlay::Settings { selected, rect }) = self.overlay.as_mut() else {
+        let Some(Overlay::Settings {
+            selected,
+            rect,
+            scroll,
+        }) = self.overlay.as_mut()
+        else {
             return;
         };
         let height = (rows.len() as u16 + 5 + hint_lines.len() as u16).min(area.height);
@@ -1955,6 +2013,9 @@ impl App {
             height,
         );
         *rect = popup;
+        let inner_height = usize::from(height.saturating_sub(2));
+        let content_height = rows.len() + 3 + hint_lines.len();
+        *scroll = keep_visible_scroll(*selected, inner_height, content_height);
 
         let inner_w = usize::from(width.saturating_sub(2));
         let mut lines: Vec<Line> = Vec::new();
@@ -1964,9 +2025,7 @@ impl App {
             let style = if !enabled {
                 Style::default().dim()
             } else if i == *selected {
-                Style::default()
-                    .bg(Color::DarkGray)
-                    .add_modifier(Modifier::BOLD)
+                selection_style(true)
             } else {
                 Style::default()
             };
@@ -1982,7 +2041,7 @@ impl App {
 
         frame.render_widget(Clear, popup);
         frame.render_widget(
-            Paragraph::new(lines).block(
+            Paragraph::new(lines).scroll((*scroll as u16, 0)).block(
                 Block::bordered()
                     .title(" Settings ")
                     .border_style(Style::default().dim()),
@@ -2336,24 +2395,57 @@ impl App {
             .get(self.active)
             .map(|r| sidebar::scm_path_key(r.git.root()));
         let selected = self.selected.and_then(|i| self.row_stable_id(i));
+        let drafts = self
+            .repos
+            .iter()
+            .filter(|repo| !repo.message.is_empty())
+            .map(|repo| {
+                (
+                    sidebar::scm_path_key(repo.git.root()),
+                    repo.message.iter().collect(),
+                )
+            })
+            .collect::<std::collections::BTreeMap<_, _>>();
+        let visible_roots = self
+            .repos
+            .iter()
+            .map(|repo| sidebar::scm_path_key(repo.git.root()))
+            .collect::<std::collections::BTreeSet<_>>();
+        let cleared_drafts = self
+            .persisted_draft_roots
+            .iter()
+            .filter(|root| visible_roots.contains(*root) && !drafts.contains_key(*root))
+            .cloned()
+            .collect();
         sidebar::ScmState {
             drawers,
             active_root,
             selected,
             history_target: self.history_target.clone(),
             scroll: self.scroll,
+            drafts,
+            cleared_drafts,
         }
     }
 
     /// Persist the view state for the next sidebar started in this cwd.
-    fn persist_scm(&self) {
+    pub fn persist_scm(&mut self) -> bool {
         let snapshot = self.snapshot_scm();
-        sidebar::save_scm_state(&self.cwd, &snapshot);
+        let mut saved = sidebar::save_scm_state(&self.cwd, &snapshot);
         for repo in &self.repos {
             if repo.git.root() != self.cwd {
-                sidebar::save_scm_state(repo.git.root(), &snapshot);
+                saved &= sidebar::save_scm_state(repo.git.root(), &snapshot);
             }
         }
+        if saved {
+            self.persisted_draft_roots
+                .retain(|root| !snapshot.cleared_drafts.contains(root));
+            self.persisted_draft_roots
+                .extend(snapshot.drafts.keys().cloned());
+        } else {
+            self.flash = Some(("Could not save Source Control state; action cancelled.".into(), true));
+        }
+        saved
     }
 
     /// `o`: open the diff for the currently selected file row.
@@ -2664,6 +2756,7 @@ impl App {
             Err(e) => self.flash = Some((e, true)),
         }
         self.refresh();
+        self.persist_scm();
     }
 
     /// Screen lines a row occupies; the inline message boxes grow with
@@ -2819,7 +2912,7 @@ impl App {
         frame.render_widget(
             Paragraph::new(Span::styled(
                 "«",
-                Style::default().bold().fg(Color::LightBlue),
+                Style::default().bold().fg(palette().header_accent),
             ))
             .centered(),
             footer_button,
@@ -2845,9 +2938,7 @@ impl App {
         let (exp_icon, git_icon) = activity_icons(self.theme);
         let active = |on: bool| {
             if on {
-                Style::default()
-                    .bg(Color::DarkGray)
-                    .add_modifier(Modifier::BOLD)
+                selection_style(true)
             } else {
                 Style::default().dim()
             }
@@ -2883,7 +2974,7 @@ impl App {
         let chip_w = chip_end.saturating_sub(chip_start);
         let cap = |glyph: &str| {
             Paragraph::new(glyph.repeat(usize::from(chip_w)))
-                .style(Style::default().fg(Color::DarkGray))
+                .style(Style::default().fg(palette().selection_bg))
         };
         frame.render_widget(cap("▄"), Rect::new(chip_start, outer_top, chip_w, 1));
         frame.render_widget(cap("▀"), Rect::new(chip_start, outer_bottom, chip_w, 1));
@@ -2974,7 +3065,7 @@ impl App {
     fn draw_message(&mut self, frame: &mut Frame, area: Rect) {
         let focused = self.focus == Focus::Message;
         let border = if focused {
-            Style::default().fg(BUTTON_BLUE)
+            Style::default().fg(palette().accent)
         } else {
             Style::default().dim()
         };
@@ -3032,11 +3123,11 @@ impl App {
     fn draw_button(&mut self, frame: &mut Frame, area: Rect) {
         let focused = self.focus == Focus::Commit;
         let bg = if focused {
-            BUTTON_BLUE_FOCUS
+            palette().accent_focus
         } else {
-            BUTTON_BLUE
+            palette().accent
         };
-        let mut style = Style::default().bg(bg).fg(Color::White);
+        let mut style = Style::default().bg(bg).fg(palette().accent_fg);
         if focused {
             style = style.add_modifier(Modifier::BOLD);
         }
@@ -3075,12 +3166,12 @@ impl App {
         };
         let style = if self.syncing.is_some() {
             Style::default()
-                .bg(Color::Rgb(0x2d, 0x2d, 0x33))
-                .fg(Color::Gray)
+                .bg(palette().sync_busy_bg)
+                .fg(palette().muted_button_fg)
         } else {
             Style::default()
-                .bg(Color::Rgb(0x3a, 0x3d, 0x41))
-                .fg(Color::White)
+                .bg(palette().sync_bg)
+                .fg(palette().accent_fg)
         };
         frame.render_widget(Paragraph::new(label).centered().style(style), area);
     }
@@ -3196,15 +3287,13 @@ impl App {
                 };
                 if selected == Some(i) {
                     let style = if list_focused {
-                        Style::default()
-                            .bg(Color::DarkGray)
-                            .add_modifier(Modifier::BOLD)
+                        selection_style(true)
                     } else {
-                        Style::default().bg(Color::Rgb(0x2a, 0x2d, 0x2e))
+                        selection_style(false)
                     };
                     item.style(style)
                 } else if hovered == Some(i) {
-                    item.style(Style::default().bg(HOVER_BG))
+                    item.style(hover_style())
                 } else {
                     item
                 }
@@ -3248,11 +3337,17 @@ impl App {
         let message: Option<(String, Color)> = match (&self.overlay, &self.flash) {
             (Some(Overlay::ConfirmDiscard { entry, .. }), _) => Some((
                 format!("Discard changes to '{}'? (y/N)", entry.path),
-                DELETED,
+                palette().deleted,
             )),
-            (Some(Overlay::ConfirmGit { prompt, .. }), _) => Some((prompt.clone(), DELETED)),
+            (Some(Overlay::ConfirmGit { prompt, .. }), _) => {
+                Some((prompt.clone(), palette().deleted))
+            }
             (_, Some((text, is_error))) => {
-                let color = if *is_error { DELETED } else { UNTRACKED };
+                let color = if *is_error {
+                    palette().deleted
+                } else {
+                    palette().untracked
+                };
                 let prefix = if *is_error { "" } else { "✓ " };
                 Some((format!("{prefix}{text}"), color))
             }
@@ -3351,9 +3446,7 @@ impl App {
                     let line = Line::raw(format!(" {label}"));
                     if i == *selected {
                         ListItem::new(line).style(
-                            Style::default()
-                                .bg(Color::DarkGray)
-                                .add_modifier(Modifier::BOLD),
+                            selection_style(true),
                         )
                     } else {
                         ListItem::new(line)
@@ -3486,7 +3579,7 @@ fn message_box_item(
     width: usize,
 ) -> ListItem<'static> {
     let border = if focused {
-        Style::default().fg(BUTTON_BLUE)
+        Style::default().fg(palette().accent)
     } else {
         Style::default().dim()
     };
@@ -3532,9 +3625,9 @@ fn message_box_item(
 /// right end; only the active repo's button is fully lit.
 fn commit_button_item(active: bool, focused: bool, width: usize) -> ListItem<'static> {
     let (bg, fg) = match (active, focused) {
-        (true, true) => (BUTTON_BLUE_FOCUS, Color::White),
-        (true, false) => (BUTTON_BLUE, Color::White),
-        (false, _) => (Color::Rgb(0x24, 0x45, 0x5c), Color::Rgb(0x9a, 0xb2, 0xc2)),
+        (true, true) => (palette().accent_focus, palette().accent_fg),
+        (true, false) => (palette().accent, palette().accent_fg),
+        (false, _) => (palette().muted_button_bg, palette().muted_button_fg),
     };
     let label = "✓ Commit";
     let body_w = width.saturating_sub(2);
@@ -3573,7 +3666,9 @@ fn section_item(
     };
     let badge = Span::styled(
         format!(" {count} "),
-        Style::default().bg(BADGE_BLUE).fg(Color::White),
+        Style::default()
+            .bg(palette().accent)
+            .fg(palette().accent_fg),
     );
     // Hovering shows the section-wide stage/unstage glyph before the badge.
     let action_span = action.map(|a| Span::styled(format!("{a} "), Style::default().bold()));
@@ -3603,7 +3698,9 @@ fn file_history_header(collapsed: bool, file: &str) -> ListItem<'static> {
 /// current branch (git's `%(HEAD)` renders it as `* name`).
 fn drawer_line(kind: Drawer, text: &str) -> ListItem<'static> {
     let style = match kind {
-        Drawer::Branches if text.starts_with('*') => Style::default().fg(UNTRACKED).bold(),
+        Drawer::Branches if text.starts_with('*') => {
+            Style::default().fg(palette().untracked).bold()
+        }
         _ => Style::default(),
     };
     ListItem::new(Line::from(Span::styled(format!("   {text}"), style)))

--- a/plugins/herdr-sidebar/src/scm_app.rs
+++ b/plugins/herdr-sidebar/src/scm_app.rs
@@ -413,6 +413,8 @@ enum Setting {
     SidebarWidth,
     IconTheme,
     AutoOpen,
+    StrictToggle,
+    FocusOnOpen,
     FollowCwd,
     GitDecorations,
     Hotkeys,
@@ -1761,6 +1763,28 @@ impl App {
                 true,
             ),
             (
+                Setting::StrictToggle,
+                "Strict toggle",
+                if self.sidebar_state.strict_toggle {
+                    "on"
+                } else {
+                    "off"
+                }
+                .to_string(),
+                true,
+            ),
+            (
+                Setting::FocusOnOpen,
+                "Focus on open",
+                if self.sidebar_state.focus_on_open {
+                    "on"
+                } else {
+                    "off"
+                }
+                .to_string(),
+                true,
+            ),
+            (
                 Setting::FollowCwd,
                 "Follow pane folder",
                 sidebar::follow_cwd_setting_value(self.sidebar_state.follow_cwd),
@@ -1816,6 +1840,14 @@ impl App {
             Setting::AutoOpen => {
                 self.sidebar_state =
                     sidebar::update_state(|state| state.auto_open = !state.auto_open);
+            }
+            Setting::StrictToggle => {
+                self.sidebar_state =
+                    sidebar::update_state(|state| state.strict_toggle = !state.strict_toggle);
+            }
+            Setting::FocusOnOpen => {
+                self.sidebar_state =
+                    sidebar::update_state(|state| state.focus_on_open = !state.focus_on_open);
             }
             Setting::FollowCwd => {
                 self.sidebar_state =

--- a/plugins/herdr-sidebar/src/state.rs
+++ b/plugins/herdr-sidebar/src/state.rs
@@ -133,6 +133,38 @@ impl View {
     }
 }
 
+/// Accent palette for the sidebar. `VsCode` preserves the historical RGB
+/// styling; `Terminal` uses ANSI colors so the terminal profile remaps them.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum ColorTheme {
+    VsCode,
+    Terminal,
+}
+
+impl ColorTheme {
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::VsCode => "vscode",
+            Self::Terminal => "terminal",
+        }
+    }
+
+    pub fn other(self) -> Self {
+        match self {
+            Self::VsCode => Self::Terminal,
+            Self::Terminal => Self::VsCode,
+        }
+    }
+
+    fn from_state_name(name: &str) -> Option<Self> {
+        match name {
+            "vscode" => Some(Self::VsCode),
+            "terminal" => Some(Self::Terminal),
+            _ => None,
+        }
+    }
+}
+
 /// The sticky sidebar setting, shared by both plugins.
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub struct State {
@@ -145,6 +177,9 @@ pub struct State {
     /// probe). Set the moment they toggle `i` or the Settings row, so a
     /// wrong auto-guess is corrected once and stays corrected.
     pub icons: Option<crate::icons::IconTheme>,
+    /// Accent palette. Terminal mode uses ANSI colors that inherit the
+    /// terminal profile; VS Code preserves the original fixed RGB palette.
+    pub color_theme: ColorTheme,
     /// The first-run "install a Nerd Font?" prompt was answered (either
     /// way) — never show it again.
     pub font_prompt_done: bool,
@@ -183,6 +218,7 @@ impl Default for State {
             active: View::Explorer,
             show_hotkeys: false,
             icons: None,
+            color_theme: ColorTheme::VsCode,
             font_prompt_done: false,
             auto_open: true,
             strict_toggle: false,
@@ -327,7 +363,7 @@ fn write_state(path: &Path, state: State) {
         None => String::new(),
     };
     let json = format!(
-        "{{\"merged\":{},\"active\":\"{}\",\"hotkeys\":{},\"font_prompt\":{},\"auto_open\":{},\"strict_toggle\":{},\"focus_on_open\":{},\"follow_cwd\":{},\"git_deco\":{},\"dock_right\":{},\"sidebar_width\":{}{icons}}}",
+        "{{\"merged\":{},\"active\":\"{}\",\"hotkeys\":{},\"font_prompt\":{},\"auto_open\":{},\"strict_toggle\":{},\"focus_on_open\":{},\"follow_cwd\":{},\"git_deco\":{},\"dock_right\":{},\"sidebar_width\":{},\"colors\":\"{}\"{icons}}}",
         state.merged,
         state.active.state_name(),
         state.show_hotkeys,
@@ -338,7 +374,8 @@ fn write_state(path: &Path, state: State) {
         state.follow_cwd,
         state.git_deco,
         state.dock_right,
-        clamp_sidebar_width(state.sidebar_width)
+        clamp_sidebar_width(state.sidebar_width),
+        state.color_theme.label()
     );
     let _ = std::fs::write(path, json);
 }
@@ -489,7 +526,8 @@ pub fn save_tree_state(root: &Path, state: &TreeState) {
 
 /// The SCM view state worth mirroring into a fresh sidebar: which drawers
 /// are expanded (by title), the active repo's root, a stable id for the
-/// selected row, the FILE HISTORY target, and the scroll offset.
+/// selected row, the FILE HISTORY target, the scroll offset, and commit
+/// drafts keyed by repository root.
 #[derive(Default)]
 pub struct ScmState {
     pub drawers: Vec<String>,
@@ -497,6 +535,10 @@ pub struct ScmState {
     pub selected: Option<String>,
     pub history_target: Option<String>,
     pub scroll: usize,
+    pub drafts: std::collections::BTreeMap<String, String>,
+    /// Draft roots this pane previously observed and has since emptied.
+    /// Kept out of the JSON shape; it only scopes merge-on-write removals.
+    pub cleared_drafts: std::collections::BTreeSet<String>,
 }
 
 fn scm_path() -> Option<PathBuf> {
@@ -558,6 +600,21 @@ fn scm_state_for(file: &ScmFile, cwd: &Path) -> ScmState {
             .and_then(|v| v.as_str())
             .map(str::to_string),
         scroll: entry.get("scroll").and_then(|v| v.as_u64()).unwrap_or(0) as usize,
+        drafts: entry
+            .get("drafts")
+            .and_then(|v| v.as_object())
+            .map(|drafts| {
+                drafts
+                    .iter()
+                    .filter_map(|(root, message)| {
+                        message
+                            .as_str()
+                            .map(|message| (scm_path_key(Path::new(root)), message.to_string()))
+                    })
+                    .collect()
+            })
+            .unwrap_or_default(),
+        cleared_drafts: std::collections::BTreeSet::new(),
     }
 }
 
@@ -569,19 +626,25 @@ pub fn load_scm_state(cwd: &Path) -> ScmState {
     scm_state_for(&decode_scm_file(&json), cwd)
 }
 
-/// Best-effort persist of `cwd`'s entry, leaving every other cwd's alone.
-pub fn save_scm_state(cwd: &Path, state: &ScmState) {
-    let Some(path) = scm_path() else { return };
-    if let Some(dir) = path.parent() {
-        let _ = std::fs::create_dir_all(dir);
+/// Persist `cwd`'s entry, leaving every other cwd's alone. Returns false when
+/// the write cannot be completed, so a graceful-close caller can keep the TUI
+/// alive instead of acknowledging data it did not save.
+pub fn save_scm_state(cwd: &Path, state: &ScmState) -> bool {
+    let Some(path) = scm_path() else { return false };
+    if let Some(dir) = path.parent()
+        && std::fs::create_dir_all(dir).is_err()
+    {
+        return false;
     }
     let Some(_lock) = StateWriteLock::acquire(&path) else {
-        return;
+        return false;
     };
     let mut file = std::fs::read_to_string(&path)
         .map(|json| decode_scm_file(&json))
         .unwrap_or_default();
     let key = scm_path_key(cwd);
+    let mut drafts = scm_state_for(&file, cwd).drafts;
+    merge_scm_drafts(&mut drafts, state);
     file.retain(|stored, _| scm_path_key(Path::new(stored)) != key);
     file.insert(
         key,
@@ -591,11 +654,22 @@ pub fn save_scm_state(cwd: &Path, state: &ScmState) {
             "selected": state.selected,
             "history_target": state.history_target,
             "scroll": state.scroll,
+            "drafts": drafts,
         }),
     );
-    if let Ok(json) = serde_json::to_string(&file) {
-        let _ = std::fs::write(path, json);
+    serde_json::to_string(&file)
+        .ok()
+        .is_some_and(|json| std::fs::write(path, json).is_ok())
+}
+
+fn merge_scm_drafts(
+    stored: &mut std::collections::BTreeMap<String, String>,
+    state: &ScmState,
+) {
+    for root in &state.cleared_drafts {
+        stored.remove(root);
     }
+    stored.extend(state.drafts.clone());
 }
 
 // ---------------------------------------------------------------------------
@@ -693,6 +767,11 @@ pub fn parse_state(json: &str) -> State {
             .get("icons")
             .and_then(|v| v.as_str())
             .and_then(crate::icons::IconTheme::from_state_name),
+        color_theme: value
+            .get("colors")
+            .and_then(|v| v.as_str())
+            .and_then(ColorTheme::from_state_name)
+            .unwrap_or(default.color_theme),
         font_prompt_done: value
             .get("font_prompt")
             .and_then(|v| v.as_bool())
@@ -800,13 +879,34 @@ mod tests {
     #[test]
     fn scm_keys_ignore_windows_separator_spelling() {
         let file = decode_scm_file(
-            r#"{"C:/repo":{"drawers":["CHANGES"],"active_root":"C:/repo","scroll":4}}"#,
+            r#"{"C:/repo":{"drawers":["CHANGES"],"active_root":"C:/repo","scroll":4,"drafts":{"C:/repo":"keep me"}}}"#,
         );
         let state = scm_state_for(&file, Path::new(r"C:\repo"));
         assert_eq!(state.drawers, vec!["CHANGES"]);
         assert_eq!(state.active_root.as_deref(), Some("C:/repo"));
         assert_eq!(state.scroll, 4);
+        assert_eq!(state.drafts.get("C:/repo").map(String::as_str), Some("keep me"));
         assert_eq!(scm_path_key(Path::new(r"C:\repo\src")), "C:/repo/src");
+    }
+
+    #[test]
+    fn scm_draft_merge_preserves_unobserved_sibling_writes() {
+        let mut stored = std::collections::BTreeMap::from([
+            ("/repo/a".to_string(), "newer sibling draft".to_string()),
+            ("/repo/b".to_string(), "draft to clear".to_string()),
+        ]);
+        let mut state = ScmState::default();
+        state
+            .cleared_drafts
+            .insert("/repo/b".to_string());
+
+        merge_scm_drafts(&mut stored, &state);
+
+        assert_eq!(
+            stored.get("/repo/a").map(String::as_str),
+            Some("newer sibling draft")
+        );
+        assert!(!stored.contains_key("/repo/b"));
     }
 
     /// Older files were a bare array, then a flat object. Both predate
@@ -835,6 +935,7 @@ mod tests {
             active: View::SourceControl,
             show_hotkeys: true,
             icons: Some(crate::icons::IconTheme::Emoji),
+            color_theme: ColorTheme::Terminal,
             font_prompt_done: true,
             auto_open: false,
             strict_toggle: true,
@@ -844,7 +945,7 @@ mod tests {
             dock_right: true,
             sidebar_width: 44,
         };
-        let json = "{\"merged\":true,\"active\":\"source-control\",\"hotkeys\":true,\"font_prompt\":true,\"auto_open\":false,\"strict_toggle\":true,\"focus_on_open\":false,\"follow_cwd\":false,\"git_deco\":false,\"dock_right\":true,\"sidebar_width\":44,\"icons\":\"emoji\"}";
+        let json = "{\"merged\":true,\"active\":\"source-control\",\"hotkeys\":true,\"font_prompt\":true,\"auto_open\":false,\"strict_toggle\":true,\"focus_on_open\":false,\"follow_cwd\":false,\"git_deco\":false,\"dock_right\":true,\"sidebar_width\":44,\"colors\":\"terminal\",\"icons\":\"emoji\"}";
         assert_eq!(parse_state(json), state);
         assert!(parse_state("\u{feff}{\"merged\":true}").merged);
         // Files written before the flag existed keep auto-open AND the git
@@ -854,6 +955,10 @@ mod tests {
         // historical toggle behavior: focus an open sidebar, focus on open.
         assert!(!parse_state("{\"merged\":true}").strict_toggle);
         assert!(parse_state("{\"merged\":true}").focus_on_open);
+        assert_eq!(
+            parse_state("{\"merged\":true}").color_theme,
+            ColorTheme::VsCode
+        );
         // Existing installs get neighbour following by default.
         assert!(parse_state("{\"merged\":true}").follow_cwd);
         assert!(parse_state("{\"merged\":true}").git_deco);

--- a/plugins/herdr-sidebar/src/state.rs
+++ b/plugins/herdr-sidebar/src/state.rs
@@ -153,6 +153,13 @@ pub struct State {
     /// open-sidebar toggle themselves (issue #8); the explicit toggle always
     /// works regardless.
     pub auto_open: bool,
+    /// The open-sidebar toggle treats an open-but-unfocused sidebar as CLOSE
+    /// instead of FOCUS: one press opens, the next press closes, wherever
+    /// focus is. Off keeps the historical open / focus / close cycle.
+    pub strict_toggle: bool,
+    /// Focus the sidebar once the toggle opens it. Off docks it in the
+    /// background: focus stays in the pane the toggle was invoked from.
+    pub focus_on_open: bool,
     /// Follow the live foreground cwd of a non-sidebar pane in this tab.
     /// Manual folder choices win until an already-observed pane changes cwd.
     pub follow_cwd: bool,
@@ -178,6 +185,8 @@ impl Default for State {
             icons: None,
             font_prompt_done: false,
             auto_open: true,
+            strict_toggle: false,
+            focus_on_open: true,
             follow_cwd: true,
             git_deco: true,
             dock_right: false,
@@ -318,12 +327,14 @@ fn write_state(path: &Path, state: State) {
         None => String::new(),
     };
     let json = format!(
-        "{{\"merged\":{},\"active\":\"{}\",\"hotkeys\":{},\"font_prompt\":{},\"auto_open\":{},\"follow_cwd\":{},\"git_deco\":{},\"dock_right\":{},\"sidebar_width\":{}{icons}}}",
+        "{{\"merged\":{},\"active\":\"{}\",\"hotkeys\":{},\"font_prompt\":{},\"auto_open\":{},\"strict_toggle\":{},\"focus_on_open\":{},\"follow_cwd\":{},\"git_deco\":{},\"dock_right\":{},\"sidebar_width\":{}{icons}}}",
         state.merged,
         state.active.state_name(),
         state.show_hotkeys,
         state.font_prompt_done,
         state.auto_open,
+        state.strict_toggle,
+        state.focus_on_open,
         state.follow_cwd,
         state.git_deco,
         state.dock_right,
@@ -690,6 +701,14 @@ pub fn parse_state(json: &str) -> State {
             .get("auto_open")
             .and_then(|v| v.as_bool())
             .unwrap_or(default.auto_open),
+        strict_toggle: value
+            .get("strict_toggle")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(default.strict_toggle),
+        focus_on_open: value
+            .get("focus_on_open")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(default.focus_on_open),
         follow_cwd: value
             .get("follow_cwd")
             .and_then(|v| v.as_bool())
@@ -818,17 +837,23 @@ mod tests {
             icons: Some(crate::icons::IconTheme::Emoji),
             font_prompt_done: true,
             auto_open: false,
+            strict_toggle: true,
+            focus_on_open: false,
             follow_cwd: false,
             git_deco: false,
             dock_right: true,
             sidebar_width: 44,
         };
-        let json = "{\"merged\":true,\"active\":\"source-control\",\"hotkeys\":true,\"font_prompt\":true,\"auto_open\":false,\"follow_cwd\":false,\"git_deco\":false,\"dock_right\":true,\"sidebar_width\":44,\"icons\":\"emoji\"}";
+        let json = "{\"merged\":true,\"active\":\"source-control\",\"hotkeys\":true,\"font_prompt\":true,\"auto_open\":false,\"strict_toggle\":true,\"focus_on_open\":false,\"follow_cwd\":false,\"git_deco\":false,\"dock_right\":true,\"sidebar_width\":44,\"icons\":\"emoji\"}";
         assert_eq!(parse_state(json), state);
         assert!(parse_state("\u{feff}{\"merged\":true}").merged);
         // Files written before the flag existed keep auto-open AND the git
         // decorations on.
         assert!(parse_state("{\"merged\":true}").auto_open);
+        // Files written before the toggle settings existed keep the
+        // historical toggle behavior: focus an open sidebar, focus on open.
+        assert!(!parse_state("{\"merged\":true}").strict_toggle);
+        assert!(parse_state("{\"merged\":true}").focus_on_open);
         // Existing installs get neighbour following by default.
         assert!(parse_state("{\"merged\":true}").follow_cwd);
         assert!(parse_state("{\"merged\":true}").git_deco);

--- a/plugins/herdr-sidebar/src/ui.rs
+++ b/plugins/herdr-sidebar/src/ui.rs
@@ -5,42 +5,167 @@
 
 use ratatui::Frame;
 use ratatui::layout::Rect;
-use ratatui::style::{Color, Style};
+use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
 use ratatui::widgets::{Scrollbar, ScrollbarOrientation, ScrollbarState};
+use std::sync::atomic::{AtomicU8, Ordering};
 
 use crate::icons::IconTheme;
-use crate::state::View;
+use crate::state::{ColorTheme, View};
 
 /// Keycap chip colors for the footer hints — a subtle "keyboard key" look
 /// instead of a wall of dim text.
-pub const KEYCAP_BG: Color = Color::Rgb(0x32, 0x36, 0x3d);
-pub const KEYCAP_FG: Color = Color::Rgb(0xc9, 0xce, 0xd6);
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct Palette {
+    pub keycap_bg: Color,
+    pub keycap_fg: Color,
+    pub modified: Color,
+    pub untracked: Color,
+    pub added: Color,
+    pub renamed: Color,
+    pub deleted: Color,
+    pub conflict: Color,
+    pub ignored: Color,
+    pub selection_bg: Color,
+    pub selection_unfocused_bg: Color,
+    pub hover_bg: Color,
+    pub accent: Color,
+    pub accent_focus: Color,
+    pub accent_fg: Color,
+    pub muted_button_bg: Color,
+    pub muted_button_fg: Color,
+    pub sync_bg: Color,
+    pub sync_busy_bg: Color,
+    pub header_accent: Color,
+}
 
 // VS Code's dark-theme git decoration colors, shared by the Source Control
 // rows and the Explorer's status decorations (issue #19) so one status letter
 // always means one color.
-pub const MODIFIED: Color = Color::Rgb(0xe2, 0xc0, 0x8d);
-pub const UNTRACKED: Color = Color::Rgb(0x73, 0xc9, 0x91);
-pub const ADDED: Color = Color::Rgb(0x81, 0xb8, 0x8b);
-pub const RENAMED: Color = Color::Rgb(0x73, 0xc9, 0x91);
-pub const DELETED: Color = Color::Rgb(0xc7, 0x4e, 0x39);
-pub const CONFLICT: Color = Color::Rgb(0xe4, 0x67, 0x6b);
-/// Ignored paths render faded, like VS Code's `gitDecoration.ignoredResourceForeground`.
-pub const IGNORED: Color = Color::Rgb(0x6b, 0x6b, 0x6b);
+const VSCODE_PALETTE: Palette = Palette {
+    keycap_bg: Color::Rgb(0x32, 0x36, 0x3d),
+    keycap_fg: Color::Rgb(0xc9, 0xce, 0xd6),
+    modified: Color::Rgb(0xe2, 0xc0, 0x8d),
+    untracked: Color::Rgb(0x73, 0xc9, 0x91),
+    added: Color::Rgb(0x81, 0xb8, 0x8b),
+    renamed: Color::Rgb(0x73, 0xc9, 0x91),
+    deleted: Color::Rgb(0xc7, 0x4e, 0x39),
+    conflict: Color::Rgb(0xe4, 0x67, 0x6b),
+    ignored: Color::Rgb(0x6b, 0x6b, 0x6b),
+    selection_bg: Color::DarkGray,
+    selection_unfocused_bg: Color::Rgb(0x2a, 0x2d, 0x2e),
+    hover_bg: Color::Rgb(48, 52, 60),
+    accent: Color::Rgb(0x00, 0x78, 0xd4),
+    accent_focus: Color::Rgb(0x02, 0x8a, 0xf0),
+    accent_fg: Color::White,
+    muted_button_bg: Color::Rgb(0x24, 0x45, 0x5c),
+    muted_button_fg: Color::Rgb(0x9a, 0xb2, 0xc2),
+    sync_bg: Color::Rgb(0x3a, 0x3d, 0x41),
+    sync_busy_bg: Color::Rgb(0x2d, 0x2d, 0x33),
+    header_accent: Color::LightBlue,
+};
+
+const TERMINAL_PALETTE: Palette = Palette {
+    keycap_bg: Color::DarkGray,
+    keycap_fg: Color::White,
+    modified: Color::Yellow,
+    untracked: Color::Green,
+    added: Color::LightGreen,
+    renamed: Color::Green,
+    deleted: Color::Red,
+    conflict: Color::LightRed,
+    ignored: Color::DarkGray,
+    selection_bg: Color::DarkGray,
+    selection_unfocused_bg: Color::Black,
+    hover_bg: Color::Black,
+    accent: Color::Blue,
+    accent_focus: Color::LightBlue,
+    accent_fg: Color::White,
+    muted_button_bg: Color::Black,
+    muted_button_fg: Color::Gray,
+    sync_bg: Color::DarkGray,
+    sync_busy_bg: Color::Black,
+    header_accent: Color::LightBlue,
+};
+
+static ACTIVE_PALETTE: AtomicU8 = AtomicU8::new(0);
+
+pub fn set_color_theme(theme: ColorTheme) {
+    ACTIVE_PALETTE.store(u8::from(theme == ColorTheme::Terminal), Ordering::Relaxed);
+}
+
+pub fn palette_for(theme: ColorTheme) -> Palette {
+    match theme {
+        ColorTheme::VsCode => VSCODE_PALETTE,
+        ColorTheme::Terminal => TERMINAL_PALETTE,
+    }
+}
+
+pub fn palette() -> Palette {
+    if ACTIVE_PALETTE.load(Ordering::Relaxed) == 1 {
+        TERMINAL_PALETTE
+    } else {
+        VSCODE_PALETTE
+    }
+}
+
+fn active_color_theme() -> ColorTheme {
+    if ACTIVE_PALETTE.load(Ordering::Relaxed) == 1 {
+        ColorTheme::Terminal
+    } else {
+        ColorTheme::VsCode
+    }
+}
+
+fn selection_style_for(theme: ColorTheme, focused: bool) -> Style {
+    if theme == ColorTheme::Terminal {
+        let style = Style::default().add_modifier(Modifier::REVERSED);
+        if focused {
+            style.add_modifier(Modifier::BOLD)
+        } else {
+            style
+        }
+    } else if focused {
+        Style::default()
+            .bg(VSCODE_PALETTE.selection_bg)
+            .add_modifier(Modifier::BOLD)
+    } else {
+        Style::default().bg(VSCODE_PALETTE.selection_unfocused_bg)
+    }
+}
+
+pub fn selection_style(focused: bool) -> Style {
+    selection_style_for(active_color_theme(), focused)
+}
+
+pub fn hover_style() -> Style {
+    if active_color_theme() == ColorTheme::Terminal {
+        Style::default().add_modifier(Modifier::REVERSED | Modifier::DIM)
+    } else {
+        Style::default().bg(VSCODE_PALETTE.hover_bg)
+    }
+}
+
+pub fn keep_visible_scroll(selected: usize, visible: usize, content: usize) -> usize {
+    selected
+        .saturating_add(1)
+        .saturating_sub(visible)
+        .min(content.saturating_sub(visible))
+}
 
 /// The color for a git status letter (`crate::git::FileEntry::letter`, plus
 /// `I` for ignored). Shared vocabulary: the Explorer decorations and the
 /// Source Control list must never disagree about what `M` looks like.
 pub fn status_color(letter: char) -> Color {
+    let colors = palette();
     match letter {
-        'M' => MODIFIED,
-        'U' => UNTRACKED,
-        'A' => ADDED,
-        'R' | 'C' => RENAMED,
-        'D' => DELETED,
-        '!' => CONFLICT,
-        'I' => IGNORED,
+        'M' => colors.modified,
+        'U' => colors.untracked,
+        'A' => colors.added,
+        'R' | 'C' => colors.renamed,
+        'D' => colors.deleted,
+        '!' => colors.conflict,
+        'I' => colors.ignored,
         _ => Color::Reset,
     }
 }
@@ -58,6 +183,7 @@ pub fn wrap_hints(
     width: u16,
     reserve: u16,
 ) -> Vec<Line<'static>> {
+    let colors = palette();
     let width = usize::from(width.max(8));
     let reserve = usize::from(reserve);
     let mut lines: Vec<Vec<Span<'static>>> = vec![Vec::new()];
@@ -73,7 +199,9 @@ pub fn wrap_hints(
         line.push(Span::raw(if line.is_empty() { " " } else { "  " }));
         line.push(Span::styled(
             format!(" {key} "),
-            Style::default().bg(KEYCAP_BG).fg(KEYCAP_FG),
+            Style::default()
+                .bg(colors.keycap_bg)
+                .fg(colors.keycap_fg),
         ));
         line.push(Span::styled(format!(" {label}"), Style::default().dim()));
         used += if line.len() == 3 { w } else { 2 + w };
@@ -217,7 +345,7 @@ pub fn title_action_spans(
         let w = Span::raw(chip.as_str()).width() as u16;
         let rect = Rect::new(cx, y, w, 1);
         let style = if hover.is_some_and(|(hx, hy)| hits(rect, hx, hy)) {
-            Style::default().bg(KEYCAP_BG)
+            Style::default().bg(palette().keycap_bg)
         } else {
             Style::default().dim()
         };
@@ -359,6 +487,37 @@ pub fn sibling_panes_of(pane_list_json: &str, my_pane_id: &str, other: View) -> 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn terminal_palette_uses_terminal_mapped_ansi_colors() {
+        let terminal = palette_for(ColorTheme::Terminal);
+        let vscode = palette_for(ColorTheme::VsCode);
+        assert_eq!(terminal.modified, Color::Yellow);
+        assert_eq!(terminal.untracked, Color::Green);
+        assert_eq!(terminal.accent, Color::Blue);
+        assert_eq!(terminal.selection_bg, Color::DarkGray);
+        assert_eq!(vscode.modified, Color::Rgb(0xe2, 0xc0, 0x8d));
+        assert_eq!(vscode.accent, Color::Rgb(0x00, 0x78, 0xd4));
+        assert!(
+            selection_style_for(ColorTheme::Terminal, true)
+                .add_modifier
+                .contains(Modifier::REVERSED)
+        );
+        assert_eq!(
+            selection_style_for(ColorTheme::Terminal, true).bg,
+            None,
+            "adaptive selection must not force a dark background"
+        );
+    }
+
+    #[test]
+    fn settings_scroll_keeps_the_selected_row_visible() {
+        assert_eq!(keep_visible_scroll(0, 5, 12), 0);
+        assert_eq!(keep_visible_scroll(4, 5, 12), 0);
+        assert_eq!(keep_visible_scroll(5, 5, 12), 1);
+        assert_eq!(keep_visible_scroll(11, 5, 12), 7);
+        assert_eq!(keep_visible_scroll(2, 0, 12), 3);
+    }
 
     #[test]
     fn messages_wrap_to_narrow_panes() {

--- a/plugins/herdr-sidebar/src/ui.rs
+++ b/plugins/herdr-sidebar/src/ui.rs
@@ -119,11 +119,15 @@ fn active_color_theme() -> ColorTheme {
 
 fn selection_style_for(theme: ColorTheme, focused: bool) -> Style {
     if theme == ColorTheme::Terminal {
-        let style = Style::default().add_modifier(Modifier::REVERSED);
         if focused {
-            style.add_modifier(Modifier::BOLD)
+            Style::default()
+                .bg(TERMINAL_PALETTE.selection_bg)
+                .fg(TERMINAL_PALETTE.keycap_fg)
+                .add_modifier(Modifier::BOLD)
         } else {
-            style
+            Style::default()
+                .bg(TERMINAL_PALETTE.selection_unfocused_bg)
+                .fg(Color::White)
         }
     } else if focused {
         Style::default()
@@ -138,12 +142,18 @@ pub fn selection_style(focused: bool) -> Style {
     selection_style_for(active_color_theme(), focused)
 }
 
-pub fn hover_style() -> Style {
-    if active_color_theme() == ColorTheme::Terminal {
-        Style::default().add_modifier(Modifier::REVERSED | Modifier::DIM)
+fn hover_style_for(theme: ColorTheme) -> Style {
+    if theme == ColorTheme::Terminal {
+        Style::default()
+            .bg(TERMINAL_PALETTE.hover_bg)
+            .fg(Color::Gray)
     } else {
         Style::default().bg(VSCODE_PALETTE.hover_bg)
     }
+}
+
+pub fn hover_style() -> Style {
+    hover_style_for(active_color_theme())
 }
 
 pub fn keep_visible_scroll(selected: usize, visible: usize, content: usize) -> usize {
@@ -345,7 +355,9 @@ pub fn title_action_spans(
         let w = Span::raw(chip.as_str()).width() as u16;
         let rect = Rect::new(cx, y, w, 1);
         let style = if hover.is_some_and(|(hx, hy)| hits(rect, hx, hy)) {
-            Style::default().bg(palette().keycap_bg)
+            Style::default()
+                .bg(palette().keycap_bg)
+                .fg(palette().keycap_fg)
         } else {
             Style::default().dim()
         };
@@ -498,15 +510,23 @@ mod tests {
         assert_eq!(terminal.selection_bg, Color::DarkGray);
         assert_eq!(vscode.modified, Color::Rgb(0xe2, 0xc0, 0x8d));
         assert_eq!(vscode.accent, Color::Rgb(0x00, 0x78, 0xd4));
-        assert!(
-            selection_style_for(ColorTheme::Terminal, true)
-                .add_modifier
-                .contains(Modifier::REVERSED)
-        );
         assert_eq!(
             selection_style_for(ColorTheme::Terminal, true).bg,
-            None,
-            "adaptive selection must not force a dark background"
+            Some(Color::DarkGray)
+        );
+        assert_eq!(
+            selection_style_for(ColorTheme::Terminal, true).fg,
+            Some(Color::White)
+        );
+        assert!(!selection_style_for(ColorTheme::Terminal, true)
+            .add_modifier
+            .contains(Modifier::REVERSED));
+        let hover = hover_style_for(ColorTheme::Terminal);
+        assert_eq!(hover.bg, Some(Color::Black));
+        assert_eq!(hover.fg, Some(Color::Gray));
+        assert_eq!(
+            selection_style_for(ColorTheme::Terminal, false).fg,
+            Some(Color::White)
         );
     }
 


### PR DESCRIPTION
## Summary

- incorporate PR #35's Strict toggle and Focus on open settings, including the missing Windows separated-SCM path
- preserve Source Control drafts during graceful toggle closes and guard AltGr input
- install checksum-verified release binaries with source-build fallback, including the Windows ensure sidecar
- add opt-in terminal-adaptive colors while preserving the existing VS Code palette as default
- protect maintainer-only local Claude/Codex commands from contributed repository paths
- bump the plugin to v0.10.0 and add the cross-platform release workflow

## Validation

- `cargo test` (209 tests)
- `cargo clippy --release -- -D warnings`
- release build
- Windows and simulated Linux installer tests, including partial assets and checksum mismatch fallback
- Bash/PowerShell syntax and workflow YAML/ruleset JSON validation
- independent Claude Opus diff review: no blockers
- manual Herdr sidebar testing on Windows

This integration PR includes the contributor commits from #35 and should replace that PR.

Closes #36
Closes #37